### PR TITLE
feat: improve headers config and types

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -45,15 +45,15 @@ security: {
   headers: {
     crossOriginResourcePolicy: {
       value: 'same-origin',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     crossOriginOpenerPolicy: {
       value: 'same-origin',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     crossOriginEmbedderPolicy: {
       value: 'require-corp',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     contentSecurityPolicy: {
       value: {
@@ -67,46 +67,46 @@ security: {
         'style-src': ["'self'", 'https:', "'unsafe-inline'"],
         'upgrade-insecure-requests': true
       },
-      ...defaultGlobalRoute
+      route: '/**'
     },
     originAgentCluster: {
       value: '?1',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     referrerPolicy: {
       value: 'no-referrer',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     strictTransportSecurity: {
       value: {
         maxAge: 15552000,
         includeSubdomains: true
       },
-      ...defaultGlobalRoute
+      route: '/**'
     },
     xContentTypeOptions: {
       value: 'nosniff',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     xDNSPrefetchControl: {
       value: 'off',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     xDownloadOptions: {
       value: 'noopen',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     xFrameOptions: {
       value: 'SAMEORIGIN',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     xPermittedCrossDomainPolicies: {
       value: 'none',
-      ...defaultGlobalRoute
+      route: '/**'
     },
     xXSSProtection: {
       value: 0,
-      ...defaultGlobalRoute
+      route: '/**'
     }
   },
   requestSizeLimiter: {

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -23,12 +23,12 @@ All module configuration is the following type:
 
 ```ts
 export interface ModuleOptions {
-  headers: SecurityHeaders | boolean;
-  requestSizeLimiter: MiddlewareConfiguration<RequestSizeLimiter> | boolean;
-  rateLimiter: MiddlewareConfiguration<RateLimiter> | boolean;
-  xssValidator: MiddlewareConfiguration<XssValidator> | boolean;
-  corsHandler: MiddlewareConfiguration<CorsOptions> | boolean;
-  allowedMethodsRestricter: MiddlewareConfiguration<AllowedHTTPMethods> | boolean;
+  headers: SecurityHeaders | false;
+  requestSizeLimiter: MiddlewareConfiguration<RequestSizeLimiter> | false;
+  rateLimiter: MiddlewareConfiguration<RateLimiter> | false;
+  xssValidator: MiddlewareConfiguration<XssValidator> | false;
+  corsHandler: MiddlewareConfiguration<CorsOptions> | false;
+  allowedMethodsRestricter: MiddlewareConfiguration<AllowedHTTPMethods> | false;
   hidePoweredBy: boolean;
   basicAuth: MiddlewareConfiguration<BasicAuth> | boolean;
 }

--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -44,58 +44,70 @@ This module will by default set the following configuration options to enable mi
 security: {
   headers: {
     crossOriginResourcePolicy: {
-      value: "same-origin",
-      route: '/**',
+      value: 'same-origin',
+      ...defaultGlobalRoute
     },
     crossOriginOpenerPolicy: {
-      value: "same-origin",
-      route: '/**',
+      value: 'same-origin',
+      ...defaultGlobalRoute
     },
     crossOriginEmbedderPolicy: {
-      value: "require-corp",
-      route: '/**',
+      value: 'require-corp',
+      ...defaultGlobalRoute
     },
     contentSecurityPolicy: {
-      value:
-        "base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
-      route: '/**',
+      value: {
+        'base-uri': ["'self'"],
+        'font-src': ["'self'", 'https:', 'data:'],
+        'form-action': ["'self'"],
+        'frame-ancestors': ["'self'"],
+        'img-src': ["'self'", 'data:'],
+        'object-src': ["'none'"],
+        'script-src-attr': ["'none'"],
+        'style-src': ["'self'", 'https:', "'unsafe-inline'"],
+        'upgrade-insecure-requests': true
+      },
+      ...defaultGlobalRoute
     },
     originAgentCluster: {
-      value: "?1",
-      route: '/**',
+      value: '?1',
+      ...defaultGlobalRoute
     },
     referrerPolicy: {
-      value: "no-referrer",
-      route: '/**',
+      value: 'no-referrer',
+      ...defaultGlobalRoute
     },
     strictTransportSecurity: {
-      value: "max-age=15552000; includeSubDomains",
-      route: '/**',
+      value: {
+        maxAge: 15552000,
+        includeSubdomains: true
+      },
+      ...defaultGlobalRoute
     },
     xContentTypeOptions: {
-      value: "nosniff",
-      route: '/**',
+      value: 'nosniff',
+      ...defaultGlobalRoute
     },
     xDNSPrefetchControl: {
-      value: "off",
-      route: '/**',
+      value: 'off',
+      ...defaultGlobalRoute
     },
     xDownloadOptions: {
-      value: "noopen",
-      route: '/**',
+      value: 'noopen',
+      ...defaultGlobalRoute
     },
     xFrameOptions: {
-      value: "SAMEORIGIN",
-      route: '/**',
+      value: 'SAMEORIGIN',
+      ...defaultGlobalRoute
     },
     xPermittedCrossDomainPolicies: {
-      value: "none",
-      route: '/**',
+      value: 'none',
+      ...defaultGlobalRoute
     },
     xXSSProtection: {
       value: 0,
-      route: '/**',
-    },
+      ...defaultGlobalRoute
+    }
   },
   requestSizeLimiter: {
     value: {

--- a/docs/content/2.middlewares/1.headers.md
+++ b/docs/content/2.middlewares/1.headers.md
@@ -14,19 +14,19 @@ export type MiddlewareConfiguration<MIDDLEWARE> = {
 }
 
 export type SecurityHeaders = {
-  crossOriginResourcePolicy: MiddlewareConfiguration<string> | boolean;
-  crossOriginOpenerPolicy: MiddlewareConfiguration<string> | boolean;
-  crossOriginEmbedderPolicy: MiddlewareConfiguration<string> | boolean;
-  contentSecurityPolicy: MiddlewareConfiguration<string> | boolean;
-  originAgentCluster: MiddlewareConfiguration<string> | boolean;
-  referrerPolicy: MiddlewareConfiguration<string> | boolean;
-  strictTransportSecurity: MiddlewareConfiguration<string> | boolean;
-  xContentTypeOptions: MiddlewareConfiguration<string> | boolean;
-  xDNSPrefetchControl: MiddlewareConfiguration<string> | boolean;
-  xDownloadOptions: MiddlewareConfiguration<string> | boolean;
-  xFrameOptions: MiddlewareConfiguration<string> | boolean;
-  xPermittedCrossDomainPolicies: MiddlewareConfiguration<string> | boolean;
-  xXSSProtection: MiddlewareConfiguration<number> | boolean;
+  crossOriginResourcePolicy: MiddlewareConfiguration<string> | false;
+  crossOriginOpenerPolicy: MiddlewareConfiguration<string> | false;
+  crossOriginEmbedderPolicy: MiddlewareConfiguration<string> | false;
+  contentSecurityPolicy: MiddlewareConfiguration<string> | false;
+  originAgentCluster: MiddlewareConfiguration<string> | false;
+  referrerPolicy: MiddlewareConfiguration<string> | false;
+  strictTransportSecurity: MiddlewareConfiguration<string> | false;
+  xContentTypeOptions: MiddlewareConfiguration<string> | false;
+  xDNSPrefetchControl: MiddlewareConfiguration<string> | false;
+  xDownloadOptions: MiddlewareConfiguration<string> | false;
+  xFrameOptions: MiddlewareConfiguration<string> | false;
+  xPermittedCrossDomainPolicies: MiddlewareConfiguration<string> | false;
+  xXSSProtection: MiddlewareConfiguration<number> | false;
 };
 ```
 
@@ -166,7 +166,7 @@ Default value:
 
 ```ts
 xContentTypeOptions: {
-  value: "nosniff", 
+  value: "nosniff",
   route: '/**',
 },
 ```

--- a/docs/content/2.middlewares/1.headers.md
+++ b/docs/content/2.middlewares/1.headers.md
@@ -14,18 +14,18 @@ export type MiddlewareConfiguration<MIDDLEWARE> = {
 }
 
 export type SecurityHeaders = {
-  crossOriginResourcePolicy: MiddlewareConfiguration<string> | false;
-  crossOriginOpenerPolicy: MiddlewareConfiguration<string> | false;
-  crossOriginEmbedderPolicy: MiddlewareConfiguration<string> | false;
-  contentSecurityPolicy: MiddlewareConfiguration<string> | false;
-  originAgentCluster: MiddlewareConfiguration<string> | false;
-  referrerPolicy: MiddlewareConfiguration<string> | false;
-  strictTransportSecurity: MiddlewareConfiguration<string> | false;
-  xContentTypeOptions: MiddlewareConfiguration<string> | false;
-  xDNSPrefetchControl: MiddlewareConfiguration<string> | false;
-  xDownloadOptions: MiddlewareConfiguration<string> | false;
-  xFrameOptions: MiddlewareConfiguration<string> | false;
-  xPermittedCrossDomainPolicies: MiddlewareConfiguration<string> | false;
+  crossOriginResourcePolicy: MiddlewareConfiguration<CrossOriginResourcePolicyValue> | false;
+  crossOriginOpenerPolicy: MiddlewareConfiguration<CrossOriginOpenerPolicyValue> | false;
+  crossOriginEmbedderPolicy: MiddlewareConfiguration<CrossOriginEmbedderPolicyValue> | false;
+  contentSecurityPolicy: MiddlewareConfiguration<ContentSecurityPolicyValue | string> | false;
+  originAgentCluster: MiddlewareConfiguration<'?1'> | false;
+  referrerPolicy: MiddlewareConfiguration<ReferrerPolicyValue> | false;
+  strictTransportSecurity: MiddlewareConfiguration<StrictTransportSecurityValue | string> | false;
+  xContentTypeOptions: MiddlewareConfiguration<XContentTypeOptionsValue> | false;
+  xDNSPrefetchControl: MiddlewareConfiguration<XDnsPrefetchControlValue> | false;
+  xDownloadOptions: MiddlewareConfiguration<XDownloadOptionsValue> | false;
+  xFrameOptions: MiddlewareConfiguration<XFrameOptionsValue> | false;
+  xPermittedCrossDomainPolicies: MiddlewareConfiguration<XPermittedCrossDomainPoliciesValue> | false;
   xXSSProtection: MiddlewareConfiguration<number> | false;
 };
 ```
@@ -44,11 +44,15 @@ To write a custom logic for this middleware follow this pattern:
       xXSSProtection: {
         value: 1,
         route: '/my-custom-route'
-      }
+      },
+      contentSecurityPolicy: false
     }
   }
 }
 ```
+
+Note that setting values for certain headers only overrides the defaults for these particular headers.
+In order to disable given header, pass `false` - like the example above shows for `contentSecurityPolicy`.
 
 ## `Content-Security-Policy`
 
@@ -60,9 +64,18 @@ Default value:
 
 ```ts
 contentSecurityPolicy: {
-  value:
-    "base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
-  route: '/**',
+  value: {
+    'base-uri': ["'self'"],
+    'font-src': ["'self'", 'https:', 'data:'],
+    'form-action': ["'self'"],
+    'frame-ancestors': ["'self'"],
+    'img-src': ["'self'", 'data:'],
+    'object-src': ["'none'"],
+    'script-src-attr': ["'none'"],
+    'style-src': ["'self'", 'https:', "'unsafe-inline'"],
+    'upgrade-insecure-requests': true
+  },
+  '/**'
 }
 ```
 
@@ -76,7 +89,7 @@ Default value:
 
 ```ts
 crossOriginEmbedderPolicy: {
-  value: "require-corp",
+  value: 'require-corp',
   route: '/**',
 },
 ```
@@ -91,7 +104,7 @@ Default value:
 
 ```ts
 crossOriginOpenerPolicy: {
-  value: "same-origin",
+  value: 'same-origin',
   route: '/**',
 },
 ```
@@ -106,7 +119,7 @@ Default value:
 
 ```ts
 crossOriginResourcePolicy: {
-  value: "same-origin",
+  value: 'same-origin',
   route: '/**',
 },
 ```
@@ -121,7 +134,7 @@ Default value:
 
 ```ts
 originAgentCluster: {
-  value: "?1",
+  value: '?1',
   route: '/**',
 },
 ```
@@ -136,7 +149,7 @@ Default value:
 
 ```ts
 referrerPolicy: {
-  value: "no-referrer",
+  value: 'no-referrer',
   route: '/**',
 },
 ```
@@ -151,7 +164,7 @@ Default value:
 
 ```ts
 strictTransportSecurity: {
-  value: "max-age=15552000; includeSubDomains",
+  value: 'max-age=15552000; includeSubDomains',
   route: '/**',
 },
 ```
@@ -166,7 +179,7 @@ Default value:
 
 ```ts
 xContentTypeOptions: {
-  value: "nosniff",
+  value: 'nosniff',
   route: '/**',
 },
 ```
@@ -181,7 +194,7 @@ Default value:
 
 ```ts
 xDNSPrefetchControl: {
-  value: "off",
+  value: 'off',
   route: '/**',
 },
 ```
@@ -196,7 +209,7 @@ Default value:
 
 ```ts
 xDownloadOptions: {
-  value: "noopen",
+  value: 'noopen',
   route: '/**',
 },
 ```
@@ -211,7 +224,7 @@ Default value:
 
 ```ts
 xFrameOptions: {
-  value: "SAMEORIGIN",
+  value: 'SAMEORIGIN',
   route: '/**',
 },
 ```
@@ -226,7 +239,7 @@ Default value:
 
 ```ts
 xPermittedCrossDomainPolicies: {
-  value: "none",
+  value: 'none',
   route: '/**',
 },
 ```

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -20,8 +20,17 @@ export const defaultSecurityConfig: ModuleOptions = {
       ...defaultGlobalRoute
     },
     contentSecurityPolicy: {
-      value:
-        "base-uri 'self';font-src 'self' https: data:;form-action 'self';frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests",
+      value: {
+        'base-uri': ["'self'"],
+        'font-src': ["'self'", 'https:', 'data:'],
+        'form-action': ["'self'"],
+        'frame-ancestors': ["'self'"],
+        'img-src': ["'self'", 'data:'],
+        'object-src': ["'none'"],
+        'script-src-attr': ["'none'"],
+        'style-src': ["'self'", 'https:', "'unsafe-inline'"],
+        'upgrade-insecure-requests': true
+      },
       ...defaultGlobalRoute
     },
     originAgentCluster: {
@@ -33,7 +42,10 @@ export const defaultSecurityConfig: ModuleOptions = {
       ...defaultGlobalRoute
     },
     strictTransportSecurity: {
-      value: 'max-age=15552000; includeSubDomains',
+      value: {
+        maxAge: 15552000,
+        includeSubdomains: true
+      },
       ...defaultGlobalRoute
     },
     xContentTypeOptions: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,31 +34,126 @@ export type MiddlewareConfiguration<MIDDLEWARE> = {
   route: string;
 }
 
+export type CrossOriginResourcePolicyValue = 'same-site' | 'same-origin' | 'cross-origin';
+
+export type CrossOriginOpenerPolicyValue = 'unsafe-none' | 'same-origin-allow-popups' | 'same-origin';
+
+export type CrossOriginEmbedderPolicyValue = 'unsafe-none' | 'require-corp';
+
+export type ReferrerPolicyValue =
+  | 'no-referrer'
+  | 'no-referrer-when-downgrade'
+  | 'origin'
+  | 'origin-when-cross-origin'
+  | 'same-origin'
+  | 'strict-origin'
+  | 'strict-origin-when-cross-origin'
+  | 'unsafe-url';
+
+export type XContentTypeOptionsValue = 'nosniff';
+
+export type XDnsPrefetchControlValue = 'on' | 'off';
+
+export type XDownloadOptionsValue = 'noopen';
+
+export type XFrameOptionsValue = 'DENY' | 'SAMEORIGIN';
+
+export type XPermittedCrossDomainPoliciesValue =
+  | 'none'
+  | 'master-only'
+  | 'by-content-type'
+  | 'by-ftp-filename'
+  | 'all';
+
+// according to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#values
+export type CSPSourceValue =
+  | "'self'"
+  | "'unsafe-eval'"
+  | "'wasm-unsafe-eval'"
+  | "'unsafe-hashes'"
+  | "'unsafe-inline'"
+  | "'none'"
+  | "'strict-dynamic'"
+  | "'report-sample'"
+  // for convenient use of any hosts, protocols, hashes and binaries
+  | string;
+
+export type CSPSandboxValue =
+| 'allow-downloads'
+| 'allow-downloads-without-user-activation'
+| 'allow-forms'
+| 'allow-modals'
+| 'allow-orientation-lock'
+| 'allow-pointer-lock'
+| 'allow-popups'
+| 'allow-popups-to-escape-sandbox'
+| 'allow-presentation'
+| 'allow-same-origin'
+| 'allow-scripts'
+| 'allow-storage-access-by-user-activation'
+| 'allow-top-navigation'
+| 'allow-top-navigation-by-user-activation'
+| 'allow-top-navigation-to-custom-protocols';
+
+export type ContentSecurityPolicyValue = {
+  'child-src'?: CSPSourceValue[];
+  'connect-src'?: CSPSourceValue[];
+  'default-src'?: CSPSourceValue[];
+  'font-src'?: CSPSourceValue[];
+  'frame-src'?: CSPSourceValue[];
+  'img-src'?: CSPSourceValue[];
+  'manifest-src'?: CSPSourceValue[];
+  'media-src'?: CSPSourceValue[];
+  'object-src'?: CSPSourceValue[];
+  'prefetch-src'?: CSPSourceValue[];
+  'script-src'?: CSPSourceValue[];
+  'script-src-elem'?: CSPSourceValue[];
+  'script-src-attr'?: CSPSourceValue[];
+  'style-src'?: CSPSourceValue[];
+  'style-src-elem'?: CSPSourceValue[];
+  'style-src-attr'?: CSPSourceValue[];
+  'worker-src'?: CSPSourceValue[];
+  'base-uri'?: CSPSourceValue[];
+  'sandbox'?: CSPSandboxValue[];
+  'form-action'?: CSPSourceValue[];
+  'frame-ancestors'?: ("'self'" | "'none'" | string)[];
+  'navigate-to'?: ("'self'" | "'none'" | "'unsafe-allow-redirects'" | string)[];
+  'report-uri'?: string[];
+  'report-to'?: string[];
+  'upgrade-insecure-requests'?: boolean;
+};
+
+export type StrictTransportSecurityValue = {
+  maxAge: number;
+  includeSubdomains?: boolean;
+  preload?: boolean;
+};
+
 export type SecurityHeaders = {
-  crossOriginResourcePolicy: MiddlewareConfiguration<string> | boolean;
-  crossOriginOpenerPolicy: MiddlewareConfiguration<string> | boolean;
-  crossOriginEmbedderPolicy: MiddlewareConfiguration<string> | boolean;
-  contentSecurityPolicy: MiddlewareConfiguration<string> | boolean;
-  originAgentCluster: MiddlewareConfiguration<string> | boolean;
-  referrerPolicy: MiddlewareConfiguration<string> | boolean;
-  strictTransportSecurity: MiddlewareConfiguration<string> | boolean;
-  xContentTypeOptions: MiddlewareConfiguration<string> | boolean;
-  xDNSPrefetchControl: MiddlewareConfiguration<string> | boolean;
-  xDownloadOptions: MiddlewareConfiguration<string> | boolean;
-  xFrameOptions: MiddlewareConfiguration<string> | boolean;
-  xPermittedCrossDomainPolicies: MiddlewareConfiguration<string> | boolean;
-  xXSSProtection: MiddlewareConfiguration<number> | boolean;
+  crossOriginResourcePolicy: MiddlewareConfiguration<CrossOriginResourcePolicyValue> | false;
+  crossOriginOpenerPolicy: MiddlewareConfiguration<CrossOriginOpenerPolicyValue> | false;
+  crossOriginEmbedderPolicy: MiddlewareConfiguration<CrossOriginEmbedderPolicyValue> | false;
+  contentSecurityPolicy: MiddlewareConfiguration<ContentSecurityPolicyValue | string> | false;
+  originAgentCluster: MiddlewareConfiguration<'?1'> | false;
+  referrerPolicy: MiddlewareConfiguration<ReferrerPolicyValue> | false;
+  strictTransportSecurity: MiddlewareConfiguration<StrictTransportSecurityValue | string> | false;
+  xContentTypeOptions: MiddlewareConfiguration<XContentTypeOptionsValue> | false;
+  xDNSPrefetchControl: MiddlewareConfiguration<XDnsPrefetchControlValue> | false;
+  xDownloadOptions: MiddlewareConfiguration<XDownloadOptionsValue> | false;
+  xFrameOptions: MiddlewareConfiguration<XFrameOptionsValue> | false;
+  xPermittedCrossDomainPolicies: MiddlewareConfiguration<XPermittedCrossDomainPoliciesValue> | false;
+  xXSSProtection: MiddlewareConfiguration<number> | false;
 };
 
 export type SecurityHeader = Record<string, MiddlewareConfiguration<any>>
 
 export interface ModuleOptions {
-  headers: SecurityHeaders | boolean;
-  requestSizeLimiter: MiddlewareConfiguration<RequestSizeLimiter> | boolean;
-  rateLimiter: MiddlewareConfiguration<RateLimiter> | boolean;
-  xssValidator: MiddlewareConfiguration<XssValidator> | boolean;
-  corsHandler: MiddlewareConfiguration<CorsOptions> | boolean;
-  allowedMethodsRestricter: MiddlewareConfiguration<AllowedHTTPMethods> | boolean;
+  headers: SecurityHeaders | false;
+  requestSizeLimiter: MiddlewareConfiguration<RequestSizeLimiter> | false;
+  rateLimiter: MiddlewareConfiguration<RateLimiter> | false;
+  xssValidator: MiddlewareConfiguration<XssValidator> | false;
+  corsHandler: MiddlewareConfiguration<CorsOptions> | false;
+  allowedMethodsRestricter: MiddlewareConfiguration<AllowedHTTPMethods> | false;
   hidePoweredBy: boolean;
   basicAuth: MiddlewareConfiguration<BasicAuth> | boolean;
 }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

This change aims to:
- update the misleading `| boolean` in types where `true` is actually an unacceptable value that would break the module
- provide better typing for certain headers' values
- enable modifying only picked parts of complex headers like Content Security Policy

Especially the very last point pushed me towards proposing this change as I found it really cumbersome to copy, modify and paste the original value for CSP when trying to add [Nuxt Image](https://v1.image.nuxtjs.org/get-started/) using Cloudinary.

Change should be fully backwards-compatible (see using the string value when it's given instead of an object) - if there is any breaking change - I'll definitely rethink it and try to improve this proposal.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why) - well, there are no test in the repo 🙃 
