### PR TITLE
fix: xss protection header should be a string

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -105,7 +105,7 @@ security: {
       route: '/**'
     },
     xXSSProtection: {
-      value: 0,
+      value: '0',
       route: '/**'
     }
   },

--- a/docs/content/2.middlewares/1.headers.md
+++ b/docs/content/2.middlewares/1.headers.md
@@ -26,7 +26,7 @@ export type SecurityHeaders = {
   xDownloadOptions: MiddlewareConfiguration<XDownloadOptionsValue> | false;
   xFrameOptions: MiddlewareConfiguration<XFrameOptionsValue> | false;
   xPermittedCrossDomainPolicies: MiddlewareConfiguration<XPermittedCrossDomainPoliciesValue> | false;
-  xXSSProtection: MiddlewareConfiguration<number> | false;
+  xXSSProtection: MiddlewareConfiguration<string> | false;
 };
 ```
 
@@ -42,7 +42,7 @@ To write a custom logic for this middleware follow this pattern:
   security: {
     headers: {
       xXSSProtection: {
-        value: 1,
+        value: '1',
         route: '/my-custom-route'
       },
       contentSecurityPolicy: false
@@ -254,7 +254,7 @@ Default value:
 
 ```ts
 xXSSProtection: {
-  value: 0,
+  value: '0',
   route: '/**',
 },
 ```

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -69,7 +69,7 @@ export const defaultSecurityConfig: ModuleOptions = {
       ...defaultGlobalRoute
     },
     xXSSProtection: {
-      value: 0,
+      value: '0',
       ...defaultGlobalRoute
     }
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,7 +142,7 @@ export type SecurityHeaders = {
   xDownloadOptions: MiddlewareConfiguration<XDownloadOptionsValue> | false;
   xFrameOptions: MiddlewareConfiguration<XFrameOptionsValue> | false;
   xPermittedCrossDomainPolicies: MiddlewareConfiguration<XPermittedCrossDomainPoliciesValue> | false;
-  xXSSProtection: MiddlewareConfiguration<number> | false;
+  xXSSProtection: MiddlewareConfiguration<string> | false;
 };
 
 export type SecurityHeader = Record<string, MiddlewareConfiguration<any>>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

resolves https://github.com/Baroshem/nuxt-security/issues/66

The issue in the linked issue that this module is outputting `X-XSS-Protection` with the value of a number, which is not valid (it should be a string). This is normally not an issue but vercel complains when it sees the generate override config in `.vercel/output/config.json`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
