### PR TITLE
fix: use custom merger for options to avoid array values concatenation

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -31,4 +31,21 @@ export default defineNuxtConfig({
   //     route: '/upload-file'
   //   }
   // }
+  security: {
+    headers: {
+      contentSecurityPolicy: {
+        value: {
+          'img-src': ["'self'", 'data:', 'https://dummy.test']
+        },
+        route: '/**'
+      },
+      strictTransportSecurity: {
+        value: {
+          maxAge: 5552000,
+          includeSubdomains: true
+        },
+        route: '/**'
+      }
+    }
+  }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { resolve, normalize } from 'pathe'
 import { defineNuxtModule, addServerHandler } from '@nuxt/kit'
-import defu from 'defu'
+import defu, { createDefu } from 'defu'
 import { RuntimeConfig } from '@nuxt/schema'
 import { CorsOptions } from '@nozomuikuta/h3-cors'
 import {
@@ -23,17 +23,23 @@ declare module '@nuxt/schema' {
   }
 }
 
+const defuReplaceArray = createDefu((obj, key, value) => {
+  if (Array.isArray(obj[key]) || Array.isArray(value)) {
+    obj[key] = value
+    return true
+  }
+})
+
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-security',
     configKey: 'security'
   },
-  defaults: defaultSecurityConfig,
   setup (options, nuxt) {
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
     nuxt.options.build.transpile.push(runtimeDir)
-    nuxt.options.security = defu(nuxt.options.security, {
-      ...options
+    nuxt.options.security = defuReplaceArray(nuxt.options.security, {
+      ...defaultSecurityConfig
     })
     const securityOptions = nuxt.options.security
 


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

As pointed in #78, `defu` (both used here and in Nuxt's code) was the reason of even triplicated values in the headers.
This PR aims fixing that by applying 2 changes:
- removing defaults from module definition - so that Nuxt does not apply regular `defu` on defaults and options from the module user
- creating custom merger with `createDefu` that in case of arrays replaces the value instead of concatenating them

Fixes #78

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
