### PR TITLE
[documentation] Fixed typo for "anti-trojan-source"

### DIFF
--- a/docs/content/3.good-practices/3.use-eslint-security-plugins.md
+++ b/docs/content/3.good-practices/3.use-eslint-security-plugins.md
@@ -42,7 +42,7 @@ Add the following configuration to `.eslintrc`:
 
 ```json
 "plugins": [
-    "security-node"
+    "anti-trojan-source"
 ],
 "extends": [
     "plugin:anti-trojan-source/recommended"


### PR DESCRIPTION
Use correct plugin name. i.e. "anti-trojan-source" instead of "security-node"

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
