### PR TITLE
feat: basic auth exclude routes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ export default defineNuxtConfig({
 })
 ```
 
-And that's it! The module will now register route roules and server middlewares globally so that your application will be more secured.
+And that's it! The module will now register route rules and server middlewares globally so that your application will be more secured.
 
 ## Static site generation (SSG)
 
-This module is meant to work with SSR apps but you can also use this module in SSG apps where you will get a Content Security Policy (CSP) support via `<meta http-equiv>` tag. You can find more about configuring Content Security Policy (CSP) [here](https://nuxt-security.vercel.app/security/headers#content-security-policy).
+This module is meant to work with SSR apps, but you can also use this module in SSG apps where you will get a Content Security Policy (CSP) support via `<meta http-equiv>` tag. You can find more about configuring Content Security Policy (CSP) [here](https://nuxt-security.vercel.app/security/headers#content-security-policy).
 
 ## Configuration
 

--- a/docs/content/2.security/7.basic-auth.md
+++ b/docs/content/2.security/7.basic-auth.md
@@ -9,6 +9,7 @@ You can learn more about HTTP Authentication [here](https://developer.mozilla.or
 
 ```ts
 export type BasicAuth = {
+  exclude?: string[];
   name: string;
   pass: string;
   enabled: boolean;
@@ -22,6 +23,7 @@ To write a custom logic for this middleware follow this pattern:
 export default defineNuxtConfig({
   security: {
     basicAuth: {
+      exclude: ['/api'],
       name: 'test',
       pass: 'test',
       enabled: true,

--- a/src/runtime/server/middleware/basicAuth.ts
+++ b/src/runtime/server/middleware/basicAuth.ts
@@ -8,6 +8,7 @@ type Credentials = {
 };
 
 export type BasicAuth = {
+  exclude?: string[];
   name: string;
   pass: string;
   enabled: boolean;
@@ -19,6 +20,8 @@ const securityConfig = useRuntimeConfig().private
 export default defineEventHandler((event) => {
   const credentials = getCredentials(event.node.req)
   const basicAuthConfig: BasicAuth = securityConfig.basicAuth
+
+  if (basicAuthConfig?.exclude?.some(el => event.path?.startsWith(el))) { return }
 
   if (!credentials || !validateCredentials(credentials!, basicAuthConfig)) {
     setHeader(event, 'WWW-Authenticate', `Basic realm=${basicAuthConfig.message || 'Please enter username and password'}`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ export type XssValidator = {
 } | {};
 
 export type BasicAuth = {
+  exclude?: string[];
   name: string;
   pass: string;
   enabled: boolean;

--- a/test/basicAuth.test.ts
+++ b/test/basicAuth.test.ts
@@ -13,4 +13,10 @@ describe('[nuxt-security] Basic Auth', async () => {
     expect(res.status).toBe(401)
     expect(res.statusText).toBe('Access denied')
   })
+
+  it ('should return 200 status code for excluded route', async () => {
+    const res = await fetch('/api/hello')
+
+    expect(res.status).toBe(200)
+  })
 })

--- a/test/fixtures/basicAuth/nuxt.config.ts
+++ b/test/fixtures/basicAuth/nuxt.config.ts
@@ -6,6 +6,7 @@ export default defineNuxtConfig({
   ],
   security: {
     basicAuth: {
+      exclude: ['/api'],
       name: 'test',
       pass: 'test',
       enabled: true,

--- a/test/fixtures/basicAuth/server/api/hello.ts
+++ b/test/fixtures/basicAuth/server/api/hello.ts
@@ -1,0 +1,3 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => 'Hello World')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

New exclude option for basic auth feature. Exclude option can enable request to some routes through basic auth middleware.
For example, to allow access to `/api` routes. Also access to `/api` routes is required for using basic auth with nuxt-content. More information is in issue below.

Resolves: https://github.com/Baroshem/nuxt-security/issues/144

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
