### PR TITLE
feat: add `nonce` support to csp

### DIFF
--- a/docs/content/2.security/1.headers.md
+++ b/docs/content/2.security/1.headers.md
@@ -61,6 +61,52 @@ contentSecurityPolicy: {
 }
 ```
 
+### `Nonce support`
+
+To further increase CSP security, you can use a [nonce-based strict csp](https://web.dev/strict-csp/#what-is-a-strict-content-security-policy).
+This can be configured as follows:
+
+```ts
+export default defineNuxtConfig({
+  security: {
+    nonce: true,
+    headers: {
+      contentSecurityPolicy: {
+        'script-src': [
+          "'self'",  // fallback value for older browsers, automatically removed if `strict-dynamic` is supported.
+          "'nonce-{{nonce}}'",
+          "'strict-dynamic'"
+        ]
+      }
+    }
+  }
+})
+```
+
+This will add a `nonce` attribute to all `<script>` and `<link>` tags in your application. 
+The `nonce` value is generated per request and is added to the CSP header. This behaviour can be tweaked on a route level by using the `routeRules` option:
+
+```ts
+export default defineNuxtConfig({
+  routeRules: {
+    '/api/custom-route': {
+      nonce: false    // do not check nonce for this route (1)
+    },
+    '/api/other-route': {
+      nonce: { mode: 'check' }  // do not generate a new nonce for this route, but check it against the existing one (2)
+    }
+  }
+})
+```
+
+#### Using `nonce` in your application code
+
+If you are dynamically adding script or link tags in your application, for example using the `useHead` composable, you can get the current valid nonce value using:
+
+```ts
+const nonce = useCookie('nonce')
+```
+
 ## Cross-Origin-Embedder-Policy
 
 The HTTP Cross-Origin-Embedder-Policy (COEP) response header prevents a document from loading any cross-origin resources that don't explicitly grant the document permission.

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -79,4 +79,5 @@ export const defaultSecurityConfig = (serverlUrl: string): ModuleOptions => ({
   basicAuth: false,
   enabled: true,
   csrf: false,
+  nonce: false
 })

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -11,7 +11,8 @@ export const SECURITY_MIDDLEWARE_NAMES: SecurityMiddlewareNames = {
   corsHandler: 'corsHandler',
   allowedMethodsRestricter: 'allowedMethodsRestricter',
   basicAuth: 'basicAuth',
-  csrf: 'csrf'
+  csrf: 'csrf',
+  nonce: 'nonce'
 }
 
 export const defaultSecurityConfig = (serverlUrl: string): ModuleOptions => ({

--- a/src/module.ts
+++ b/src/module.ts
@@ -109,6 +109,14 @@ export default defineNuxtModule<ModuleOptions>({
       });
     }
 
+    if (nuxt.options.security.nonce) {
+      addServerHandler({
+        handler: normalize(
+          resolve(runtimeDir, "server/middleware/cspNonceHandler")
+        ),
+      });
+    }
+
     const allowedMethodsRestricterConfig = nuxt.options.security
       .allowedMethodsRestricter;
     if (

--- a/src/module.ts
+++ b/src/module.ts
@@ -224,6 +224,15 @@ const registerSecurityNitroPlugins = (
       );
     }
 
+    // Nitro plugin to enable nonce for CSP
+    config.plugins.push(
+      normalize(
+        fileURLToPath(
+          new URL("./runtime/nitro/plugins/cspNonce", import.meta.url)
+        )
+      )
+    );
+
     // Register nitro plugin to enable CSP for SSG
     if (
       typeof securityOptions.headers === "object" &&

--- a/src/runtime/nitro/plugins/cspNonce.ts
+++ b/src/runtime/nitro/plugins/cspNonce.ts
@@ -1,0 +1,41 @@
+import type { NitroAppPlugin } from 'nitropack'
+import type { H3Event } from 'h3'
+import type {
+  ModuleOptions
+} from '../../../types'
+import { useRuntimeConfig } from '#imports'
+
+interface NuxtRenderHTMLContext {
+  island?: boolean
+  htmlAttrs: string[]
+  head: string[]
+  bodyAttrs: string[]
+  bodyPrepend: string[]
+  body: string[]
+  bodyAppend: string[]
+}
+
+export default <NitroAppPlugin> function (nitro) {
+  nitro.hooks.hook('render:html', (html: NuxtRenderHTMLContext, { event }: { event: H3Event }) => {
+    const nonce = parseNonce(`${event.node.res.getHeader('Content-Security-Policy')}`)
+
+    if (!nonce) { return }
+
+    // Add nonce attribute to all link tags
+    html.head = html.head.map(link => link.replaceAll(/<link/g, `<link nonce="${nonce}"`))
+    html.bodyAppend = html.bodyAppend.map(link => link.replaceAll(/<link/g, `<link nonce="${nonce}"`))
+
+    // Add nonce attribute to all script tags
+    html.head = html.head.map(script => script.replaceAll(/<script/g, `<script nonce="${nonce}"`))
+    html.bodyAppend = html.bodyAppend.map(script => script.replaceAll(/<script/g, `<script nonce="${nonce}"`))
+  })
+
+  function parseNonce (content: string) {
+    const noncePattern = /nonce-([a-zA-Z0-9+/=]+)/
+    const match = content?.match(noncePattern)
+    if (match && match[1]) {
+      return match[1]
+    }
+    return null
+  }
+}

--- a/src/runtime/server/middleware/cspNonceHandler.ts
+++ b/src/runtime/server/middleware/cspNonceHandler.ts
@@ -1,0 +1,46 @@
+import crypto from 'node:crypto'
+import { createError, defineEventHandler, getCookie, sendError, setCookie } from 'h3'
+import { getRouteRules } from '#imports'
+
+export type NonceOptions = {
+  enabled: boolean;
+  mode: 'renew' | 'check';
+  value: undefined | (() => string);
+}
+
+export default defineEventHandler((event) => {
+  let csp = `${event.node.res.getHeader('Content-Security-Policy')}`
+  const routeRules = getRouteRules(event)
+
+  if (routeRules.security.nonce !== false) {
+    const nonceConfig: NonceOptions = routeRules.security.nonce
+
+    // See if we are checking the nonce against the current value, or if we are renewing the nonce value
+    let nonce: string | undefined
+    switch (nonceConfig?.mode) {
+      case 'check': {
+        nonce = getCookie(event, 'nonce')
+
+        if (!nonce) {
+          return sendError(event, createError({ statusCode: 401, statusMessage: 'Nonce is not set' }))
+        }
+
+        break
+      }
+      case 'renew':
+      default: {
+        nonce = nonceConfig?.value ? nonceConfig.value() : Buffer.from(crypto.randomUUID()).toString('base64')
+        setCookie(event, 'nonce', nonce, { sameSite: true, secure: true })
+        break
+      }
+    }
+
+    // Set actual nonce value in CSP header
+    csp = csp.replaceAll('{{nonce}}', nonce as string)
+  } else {
+    // Nonce is disabled, so make sure it's also not set in the csp header
+    csp = csp.replaceAll('\'nonce-{{nonce}}\'', '')
+  }
+
+  event.node.res.setHeader('Content-Security-Policy', csp)
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,12 @@ export type BasicAuth = {
   message: string;
 }
 
+export type NonceOptions = {
+  enabled: boolean;
+  mode?: "renew" | "check";
+  value?: (() => string);
+}
+
 // Cannot use the H3CorsOptions from `h3` as it breaks the build process for some reason :(
 export type CorsOptions = {
   origin?: "*" | "null" | string | (string | RegExp)[] | ((origin: string) => boolean);
@@ -90,6 +96,7 @@ export type CSPSourceValue =
   | "'none'"
   | "'strict-dynamic'"
   | "'report-sample'"
+  | "'nonce=<base64-value>'"
   // for convenient use of any hosts, protocols, hashes and binaries
   | string;
 
@@ -275,7 +282,7 @@ export interface ModuleOptions {
   basicAuth: MiddlewareConfiguration<BasicAuth> | BasicAuth | boolean;
   enabled: boolean;
   csrf: CsrfOptions | boolean;
-  nonce: boolean;
+  nonce: MiddlewareConfiguration<NonceOptions> | NonceOptions | boolean;
 }
 
 export interface NuxtSecurityRouteRules {
@@ -284,4 +291,5 @@ export interface NuxtSecurityRouteRules {
   xssValidator?: XssValidator | false;
   corsHandler?: CorsOptions | false;
   allowedMethodsRestricter: AllowedHTTPMethods | false;
+  nonce?: NonceOptions | false;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -275,6 +275,7 @@ export interface ModuleOptions {
   basicAuth: MiddlewareConfiguration<BasicAuth> | BasicAuth | boolean;
   enabled: boolean;
   csrf: CsrfOptions | boolean;
+  nonce: boolean;
 }
 
 export interface NuxtSecurityRouteRules {

--- a/test/fixtures/nonce/app.vue
+++ b/test/fixtures/nonce/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/nonce/nuxt.config.ts
+++ b/test/fixtures/nonce/nuxt.config.ts
@@ -3,7 +3,11 @@ import MyModule from '../../../src/module'
 export default defineNuxtConfig({
   app: {
     head: {
-      script: [{ src: '/loader.js' }, { src: '/api/generated-script' }]
+      script: [
+        { src: '/loader.js' },
+        { src: '/api/generated-script' },
+        { innerHTML: 'var inlineLiteral = \'<script>console.log("example")</script>\'' }
+      ]
     }
   },
 

--- a/test/fixtures/nonce/nuxt.config.ts
+++ b/test/fixtures/nonce/nuxt.config.ts
@@ -1,0 +1,39 @@
+import MyModule from '../../../src/module'
+
+export default defineNuxtConfig({
+  app: {
+    head: {
+      script: [{ src: '/loader.js' }, { src: '/api/generated-script' }]
+    }
+  },
+
+  modules: [
+    MyModule
+  ],
+
+  routeRules: {
+    '/api/generated-script': {
+      security: {
+        nonce: { mode: 'check' }
+      }
+    },
+    '/api/nonce-exempt': {
+      security: {
+        nonce: false
+      }
+    }
+  },
+  security: {
+    nonce: true,
+    headers: {
+      contentSecurityPolicy: {
+        'script-src': [
+          "'self'", // backwards compatibility for older browsers that don't support strict-dynamic
+          "'nonce-{{nonce}}'",
+          "'strict-dynamic'"
+        ],
+        'script-src-attr': ["'self'", "'nonce-{{nonce}}'", "'strict-dynamic'"]
+      }
+    }
+  }
+})

--- a/test/fixtures/nonce/package.json
+++ b/test/fixtures/nonce/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "basic",
+  "type": "module"
+}

--- a/test/fixtures/nonce/pages/index.vue
+++ b/test/fixtures/nonce/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    basic
+  </div>
+</template>

--- a/test/fixtures/nonce/pages/use-head.vue
+++ b/test/fixtures/nonce/pages/use-head.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>test</div>
+</template>
+
+<script lang="ts" setup>
+const nonce = useCookie('nonce')
+useHead({
+  script: () => ({
+    src: '/loader.js',
+    nonce: nonce.value
+  })
+})
+</script>

--- a/test/fixtures/nonce/public/external.js
+++ b/test/fixtures/nonce/public/external.js
@@ -1,0 +1,3 @@
+// this file is simulated to be an external file
+// it will be loaded by the loader.js
+alert('hello from external')

--- a/test/fixtures/nonce/public/loader.js
+++ b/test/fixtures/nonce/public/loader.js
@@ -1,0 +1,9 @@
+function loader() {
+  let script = document.createElement('script');
+  script.src = 'external.js';
+
+  // add to the DOM
+  document.body.appendChild(script);
+}
+
+loader();

--- a/test/fixtures/nonce/server/api/generated-script.ts
+++ b/test/fixtures/nonce/server/api/generated-script.ts
@@ -1,0 +1,6 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler((event) => {
+  event.node.res.setHeader('Content-Type', 'application/javascript')
+  return 'console.log("Hello World")'
+})

--- a/test/fixtures/nonce/server/api/nonce-exempt.ts
+++ b/test/fixtures/nonce/server/api/nonce-exempt.ts
@@ -1,0 +1,3 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(() => 'Hello World')

--- a/test/nonce.test.ts
+++ b/test/nonce.test.ts
@@ -1,0 +1,64 @@
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+import { setup, fetch } from '@nuxt/test-utils'
+
+describe('[nuxt-security] Nonce', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/nonce', import.meta.url))
+  })
+
+  it('injects `nonce` attribute in response', async () => {
+    const res = await fetch('/')
+
+    const cspHeaderValue = res.headers.get('content-security-policy')
+    const nonce = cspHeaderValue?.match(/'nonce-(.*?)'/)[1]
+
+    const text = await res.text()
+    const elementsWithNonce = text.match(new RegExp(`nonce="${nonce}"`, 'g'))?.length ?? 0
+
+    expect(res).toBeDefined()
+    expect(res).toBeTruthy()
+    expect(nonce).toBeDefined()
+    expect(elementsWithNonce).toBe(8)
+  })
+
+  it('does not renew nonce if mode is `check`', async () => {
+    // Make sure a nonce exists by doing the initial request
+    const originalRes = await fetch('/')
+    const originalCsp = originalRes.headers.get('content-security-policy')
+    const originalCookie = originalRes.headers.get('set-cookie')
+
+    // Then simulate the second request from the page to the specified route
+    const res = await fetch('/api/generated-script', { headers: { cookie: originalCookie } })
+
+    expect(res).toBeDefined()
+    expect(res).toBeTruthy()
+    expect(res.ok).toBe(true)
+    expect(res.headers.get('content-security-policy')).toBe(originalCsp)
+  })
+
+  it('injects `nonce` attribute in response when using useHead composable', async () => {
+    const res = await fetch('/use-head')
+
+    const cspHeaderValue = res.headers.get('content-security-policy')
+    const nonce = cspHeaderValue?.match(/'nonce-(.*?)'/)[1]
+
+    const text = await res.text()
+    const elementsWithNonce = text.match(new RegExp(`nonce="${nonce}"`, 'g'))?.length ?? 0
+
+    expect(res).toBeDefined()
+    expect(res).toBeTruthy()
+    expect(nonce).toBeDefined()
+    expect(elementsWithNonce).toBe(10)
+  })
+
+  it('removes the nonce from the CSP header when nonce is disabled', async () => {
+    const res = await fetch('/api/nonce-exempt')
+
+    const cspHeaderValue = res.headers.get('content-security-policy')
+    const noncesInCsp = cspHeaderValue?.match(/'nonce-(.*?)'/)?.length ?? 0
+
+    expect(noncesInCsp).toBe(0)
+    expect(cspHeaderValue).toBe("base-uri 'self'; font-src 'self' https: data:; form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src-attr 'self'  'strict-dynamic'; style-src 'self' https: 'unsafe-inline'; upgrade-insecure-requests; script-src 'self'  'strict-dynamic'")
+  })
+})

--- a/test/nonce.test.ts
+++ b/test/nonce.test.ts
@@ -19,7 +19,7 @@ describe('[nuxt-security] Nonce', async () => {
     expect(res).toBeDefined()
     expect(res).toBeTruthy()
     expect(nonce).toBeDefined()
-    expect(elementsWithNonce).toBe(8)
+    expect(elementsWithNonce).toBe(9)
   })
 
   it('does not renew nonce if mode is `check`', async () => {
@@ -49,7 +49,7 @@ describe('[nuxt-security] Nonce', async () => {
     expect(res).toBeDefined()
     expect(res).toBeTruthy()
     expect(nonce).toBeDefined()
-    expect(elementsWithNonce).toBe(10)
+    expect(elementsWithNonce).toBe(11)
   })
 
   it('removes the nonce from the CSP header when nonce is disabled', async () => {
@@ -60,5 +60,14 @@ describe('[nuxt-security] Nonce', async () => {
 
     expect(noncesInCsp).toBe(0)
     expect(cspHeaderValue).toBe("base-uri 'self'; font-src 'self' https: data:; form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src-attr 'self'  'strict-dynamic'; style-src 'self' https: 'unsafe-inline'; upgrade-insecure-requests; script-src 'self'  'strict-dynamic'")
+  })
+
+  it('does not add nonce to literal strings', async () => {
+    const res = await fetch('/')
+
+    const text = await res.text()
+    const untouchedLiteral = text.includes('var inlineLiteral = \'<script>console.log("example")</script>\'')
+
+    expect(untouchedLiteral).toBe(true)
   })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Add support for `nonce` values in CSP. 
Regenerates nonce on every request, but allows overriding this behaviour per route. 

I'm using this in production to implement a [strict csp using nonce](https://web.dev/strict-csp/#what-is-a-strict-content-security-policy).

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Resolves: #136 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
