### PR TITLE
fix: nonce quirks when using `ssr`

### DIFF
--- a/docs/content/2.security/1.headers.md
+++ b/docs/content/2.security/1.headers.md
@@ -3,7 +3,7 @@ title: Headers
 description: ''
 ---
 
-A set of **global** Nuxt `routeRules` that will add appriopriate security headers to your response that will make your application more secure by default. All headers can be overriden by using the module configuration. Check out all the available types [here](https://github.com/Baroshem/nuxt-security/blob/main/src/types.ts).
+A set of **global** Nuxt `routeRules` that will add appropriate security headers to your response that will make your application more secure by default. All headers can be overriden by using the module configuration. Check out all the available types [here](https://github.com/Baroshem/nuxt-security/blob/main/src/types.ts).
 
 It will help you solve [this](https://cheatsheetseries.owasp.org/cheatsheets/Nodejs_Security_Cheat_Sheet.html#use-appropriate-security-headers) security problem.
 
@@ -72,7 +72,16 @@ export default defineNuxtConfig({
     nonce: true,
     headers: {
       contentSecurityPolicy: {
+        'style-src': [
+          "'self'",  // fallback value for older browsers, automatically removed if `strict-dynamic` is supported.
+          "'nonce-{{nonce}}'",
+        ], 
         'script-src': [
+          "'self'",  // fallback value for older browsers, automatically removed if `strict-dynamic` is supported.
+          "'nonce-{{nonce}}'",
+          "'strict-dynamic'"
+        ],
+        'script-src-attr': [
           "'self'",  // fallback value for older browsers, automatically removed if `strict-dynamic` is supported.
           "'nonce-{{nonce}}'",
           "'strict-dynamic'"
@@ -83,7 +92,7 @@ export default defineNuxtConfig({
 })
 ```
 
-This will add a `nonce` attribute to all `<script>` and `<link>` tags in your application. 
+This will add a `nonce` attribute to all `<script>`, `<link>` and `<style>` tags in your application. 
 The `nonce` value is generated per request and is added to the CSP header. This behaviour can be tweaked on a route level by using the `routeRules` option:
 
 ```ts
@@ -101,10 +110,23 @@ export default defineNuxtConfig({
 
 #### Using `nonce` in your application code
 
-If you are dynamically adding script or link tags in your application, for example using the `useHead` composable, you can get the current valid nonce value using:
+##### With the `useHead` composable
+If you are dynamically adding script or link tags in your application using the `useHead` composable, all nonce values will be automatically added.
+However, take note that due to [a current bug in unjs/unhead](https://github.com/unjs/unhead/issues/136), you'll need to add a workaround **when using ssr** to prevent double loading and executing of your scripts when using nonce.
 
 ```ts
-const nonce = useCookie('nonce')
+// workaround unjs/unhead bug for double injection when using nonce
+// by setting the mode to 'server'
+// see: https://github.com/unjs/unhead/issues/136 
+useHead({ script: [{ src: 'https://example.com/script.js' }] }, { mode: 'server' })
+```
+
+##### Directly inserting tags into DOM
+
+If you are unable or unwilling to use `useHead` and are inserting directly into the DOM (e.g. `document.createElement`), you can get the current valid nonce value using the `useNonce` composable:
+
+```ts
+const nonce = useNonce()
 ```
 
 ## Cross-Origin-Embedder-Policy

--- a/src/module.ts
+++ b/src/module.ts
@@ -140,6 +140,10 @@ export default defineNuxtModule<ModuleOptions>({
       });
     }
 
+    nuxt.hook('imports:dirs', (dirs) => {
+      dirs.push(normalize(resolve(runtimeDir, 'composables')))
+    });
+
     const csrfConfig = nuxt.options.security.csrf;
     if (csrfConfig) {
       if (Object.keys(csrfConfig).length) {

--- a/src/runtime/composables/nonce.ts
+++ b/src/runtime/composables/nonce.ts
@@ -1,0 +1,5 @@
+import { useNuxtApp, useCookie } from '#imports'
+
+export function useNonce () {
+  return useNuxtApp().ssrContext?.event?.context.nonce ?? useCookie('nonce').value
+}

--- a/src/runtime/nitro/plugins/cspNonce.ts
+++ b/src/runtime/nitro/plugins/cspNonce.ts
@@ -34,6 +34,10 @@ export default <NitroAppPlugin> function (nitro) {
     // Add nonce attribute to all script tags
     html.head = html.head.map(script => script.replaceAll(tagNotPrecededByQuotes('script'), `<script nonce="${nonce}"`))
     html.bodyAppend = html.bodyAppend.map(script => script.replaceAll(tagNotPrecededByQuotes('script'), `<script nonce="${nonce}"`))
+
+    // Add nonce attribute to all style tags
+    html.head = html.head.map(style => style.replaceAll(tagNotPrecededByQuotes('style'), `<style nonce="${nonce}"`))
+    html.bodyAppend = html.bodyAppend.map(style => style.replaceAll(tagNotPrecededByQuotes('style'), `<style nonce="${nonce}"`))
   })
 
   function parseNonce (content: string) {

--- a/src/runtime/server/middleware/cspNonceHandler.ts
+++ b/src/runtime/server/middleware/cspNonceHandler.ts
@@ -19,7 +19,7 @@ export default defineEventHandler((event) => {
     let nonce: string | undefined
     switch (nonceConfig?.mode) {
       case 'check': {
-        nonce = getCookie(event, 'nonce')
+        nonce = event.context.nonce ?? getCookie(event, 'nonce')
 
         if (!nonce) {
           return sendError(event, createError({ statusCode: 401, statusMessage: 'Nonce is not set' }))
@@ -31,6 +31,7 @@ export default defineEventHandler((event) => {
       default: {
         nonce = nonceConfig?.value ? nonceConfig.value() : Buffer.from(crypto.randomUUID()).toString('base64')
         setCookie(event, 'nonce', nonce, { sameSite: true, secure: true })
+        event.context.nonce = nonce
         break
       }
     }

--- a/test/fixtures/nonce/app.vue
+++ b/test/fixtures/nonce/app.vue
@@ -3,3 +3,13 @@
     <NuxtPage />
   </div>
 </template>
+
+<script lang="ts" setup>
+useHead({
+  script: [
+    { src: '/api/generated-script' }
+  ]
+  // workaround for double loads in ssr when using nonce
+  // see: https://github.com/unjs/unhead/issues/136
+}, { mode: 'server' })
+</script>

--- a/test/fixtures/nonce/nuxt.config.ts
+++ b/test/fixtures/nonce/nuxt.config.ts
@@ -2,13 +2,17 @@ import MyModule from '../../../src/module'
 
 export default defineNuxtConfig({
   app: {
-    head: {
-      script: [
-        { src: '/loader.js' },
-        { src: '/api/generated-script' },
-        { innerHTML: 'var inlineLiteral = \'<script>console.log("example")</script>\'' }
-      ]
-    }
+    // workaround for double loads in ssr when using nonce
+    // see: https://github.com/unjs/unhead/issues/136
+    head: () => (process.server
+      ? {
+          script: [
+            { src: '/loader.js' },
+            { src: '/api/generated-script' },
+            { innerHTML: 'var inlineLiteral = \'<script>console.log("example")</script>\'' }
+          ]
+        }
+      : {})
   },
 
   modules: [
@@ -31,6 +35,7 @@ export default defineNuxtConfig({
     nonce: true,
     headers: {
       contentSecurityPolicy: {
+        'style-src': ["'self'", "'nonce-{{nonce}}'"],
         'script-src': [
           "'self'", // backwards compatibility for older browsers that don't support strict-dynamic
           "'nonce-{{nonce}}'",

--- a/test/fixtures/nonce/nuxt.config.ts
+++ b/test/fixtures/nonce/nuxt.config.ts
@@ -1,20 +1,6 @@
 import MyModule from '../../../src/module'
 
 export default defineNuxtConfig({
-  app: {
-    // workaround for double loads in ssr when using nonce
-    // see: https://github.com/unjs/unhead/issues/136
-    head: () => (process.server
-      ? {
-          script: [
-            { src: '/loader.js' },
-            { src: '/api/generated-script' },
-            { innerHTML: 'var inlineLiteral = \'<script>console.log("example")</script>\'' }
-          ]
-        }
-      : {})
-  },
-
   modules: [
     MyModule
   ],

--- a/test/fixtures/nonce/pages/use-head.vue
+++ b/test/fixtures/nonce/pages/use-head.vue
@@ -3,11 +3,12 @@
 </template>
 
 <script lang="ts" setup>
-const nonce = useCookie('nonce')
+const nonce = useNonce()
+
 useHead({
   script: () => ({
-    src: '/loader.js',
-    nonce: nonce.value
+    src: 'loader.js',
+    nonce
   })
 })
 </script>

--- a/test/fixtures/nonce/pages/use-head.vue
+++ b/test/fixtures/nonce/pages/use-head.vue
@@ -3,13 +3,12 @@
 </template>
 
 <script lang="ts" setup>
-const nonce = useNonce()
-
 useHead({
-  script: () => ({
-    key: 'loader',
-    src: 'loader.js',
-    nonce
-  })
+  script: () => {
+    return {
+      key: 'loader',
+      src: 'loader.js'
+    }
+  }
 }, { mode: 'server' }) // workaround double load on ssr, see https://github.com/unjs/unhead/issues/136
 </script>

--- a/test/fixtures/nonce/pages/use-head.vue
+++ b/test/fixtures/nonce/pages/use-head.vue
@@ -7,8 +7,9 @@ const nonce = useNonce()
 
 useHead({
   script: () => ({
+    key: 'loader',
     src: 'loader.js',
     nonce
   })
-})
+}, { mode: 'server' }) // workaround double load on ssr, see https://github.com/unjs/unhead/issues/136
 </script>

--- a/test/fixtures/nonce/pages/with-inline-script.vue
+++ b/test/fixtures/nonce/pages/with-inline-script.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    test
+  </div>
+</template>
+
+<script setup>
+useHead({
+  script: [
+    { innerHTML: "var inlineLiteral = '\x3Cscript>console.log(\"example\")'" }
+  ]
+}, { mode: 'server' })
+</script>

--- a/test/fixtures/nonce/pages/with-styling.vue
+++ b/test/fixtures/nonce/pages/with-styling.vue
@@ -1,0 +1,9 @@
+<template>
+  <div>test</div>
+</template>
+
+<style>
+  div {
+    color: red;
+  }
+</style>

--- a/test/fixtures/nonce/public/external.js
+++ b/test/fixtures/nonce/public/external.js
@@ -1,3 +1,3 @@
 // this file is simulated to be an external file
 // it will be loaded by the loader.js
-alert('hello from external')
+console.log('hello from external')

--- a/test/fixtures/nonce/public/loader.js
+++ b/test/fixtures/nonce/public/loader.js
@@ -3,7 +3,7 @@ function loader() {
   script.src = 'external.js';
 
   // add to the DOM
-  document.body.appendChild(script);
+  document.head.appendChild(script);
 }
 
 loader();

--- a/test/nonce.test.ts
+++ b/test/nonce.test.ts
@@ -7,6 +7,8 @@ describe('[nuxt-security] Nonce', async () => {
     rootDir: fileURLToPath(new URL('./fixtures/nonce', import.meta.url))
   })
 
+  const expectedNonceElements = 9 // 3 head scripts + 3 styles + 3 script attributes
+
   it('injects `nonce` attribute in response', async () => {
     const res = await fetch('/')
 
@@ -19,7 +21,7 @@ describe('[nuxt-security] Nonce', async () => {
     expect(res).toBeDefined()
     expect(res).toBeTruthy()
     expect(nonce).toBeDefined()
-    expect(elementsWithNonce).toBe(9)
+    expect(elementsWithNonce).toBe(expectedNonceElements)
   })
 
   it('does not renew nonce if mode is `check`', async () => {
@@ -59,7 +61,7 @@ describe('[nuxt-security] Nonce', async () => {
     const noncesInCsp = cspHeaderValue?.match(/'nonce-(.*?)'/)?.length ?? 0
 
     expect(noncesInCsp).toBe(0)
-    expect(cspHeaderValue).toBe("base-uri 'self'; font-src 'self' https: data:; form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src-attr 'self'  'strict-dynamic'; style-src 'self' https: 'unsafe-inline'; upgrade-insecure-requests; script-src 'self'  'strict-dynamic'")
+    expect(cspHeaderValue).toBe("base-uri 'self'; font-src 'self' https: data:; form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src-attr 'self'  'strict-dynamic'; style-src 'self' ; upgrade-insecure-requests; script-src 'self'  'strict-dynamic'")
   })
 
   it('does not add nonce to literal strings', async () => {


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)

## Description
When working with the recently introduced `nonce` feature I noticed some quirks that this PR aims to correct.

- `nonce`  attribute was not being applied to `<style>` elements, resulting in CSP violations
- when using `ssr` the nonce value could get out of sync
- using the `nonce` value directly is almost never needed, so the documentation should show that as well

Finally, I discovered strange behavior due to [an upstream bug in `unjs/unhead`](https://github.com/unjs/unhead/issues/136) when using nonce values.

- useHead tags are injected twice when using `nonce` and `ssr`

I've fixed these quirks and updated the tests and documentation accordingly to reflect these findings.

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
