### PR TITLE
Add throwError?: boolean to types that need it

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,12 +3,14 @@ import { ModuleOptions as CsrfOptions } from 'nuxt-csurf'
 export type RequestSizeLimiter = {
   maxRequestSizeInBytes: number;
   maxUploadFileRequestInBytes: number;
+  throwError?: boolean;
 };
 
 export type RateLimiter = {
   tokensPerInterval: number;
   interval: string | number;
   fireImmediately?: boolean;
+  throwError?: boolean;
 };
 
 export type XssValidator = {
@@ -16,6 +18,7 @@ export type XssValidator = {
   stripIgnoreTag: boolean;
   stripIgnoreTagBody: boolean;
   css: Record<string, any> | boolean;
+  throwError?: boolean;
 } | {};
 
 export type BasicAuth = {


### PR DESCRIPTION
Add `throwError?: boolean;` to RequestSizeLimiter, RateLimiter, XssValidator types so nuxt.config.ts doesn't complain when you include it.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Add `throwError?: boolean;` to RequestSizeLimiter, RateLimiter, XssValidator types so nuxt.config.ts doesn't complain when you include it.
Resolves:
https://github.com/Baroshem/nuxt-security/issues/188


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
