### PR TITLE
ci: run on all pull requests and more branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,11 @@ name: ci
 on:
   push:
     branches:
+      - alpha
+      - beta
       - main
+      - renovate/**
   pull_request:
-    branches:
-      - main
 
 jobs:
   ci:


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] CI change
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This is a proposal to let the ci run on all pull requests, e.g. for this one not going against `main`.

It also proposes to let the ci run on pushes to the typical `beta` and `alpha` branches as well as branches created by the maintenance tool `renovate`, but as that's not in use currently that change can of course be removed from this PR.
Would renovate be an option for you?


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
