### PR TITLE
Add Missing commas inside the docs examples

### DIFF
--- a/docs/content/2.security/3.rate-limiter.md
+++ b/docs/content/2.security/3.rate-limiter.md
@@ -44,7 +44,7 @@ export default defineNuxtConfig({
         rateLimiter: {
           tokensPerInterval: 200,
           interval: "day",
-          fireImmediately: false
+          fireImmediately: false,
           throwError: false, // optional
         }
       }

--- a/docs/content/2.security/4.xss-validator.md
+++ b/docs/content/2.security/4.xss-validator.md
@@ -22,7 +22,7 @@ To write a custom logic for this middleware follow this pattern:
 export default defineNuxtConfig({
   security: {
     xssValidator: {
-      stripIgnoreTag: true
+      stripIgnoreTag: true,
       throwError: false, // optional
     }
   }
@@ -37,7 +37,7 @@ export default defineNuxtConfig({
     '/my-secret-route': {
       security: {
         xssValidator: {
-          stripIgnoreTag: true
+          stripIgnoreTag: true,
           throwError: false, // optional
         }
       }


### PR DESCRIPTION
Add missing commas to Documentation of rate limiter and xss validator