### PR TITLE
feat(csp): Extend CSP support of SSG mode

### DIFF
--- a/.stackblitz/.gitignore
+++ b/.stackblitz/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .output
 .env
 dist
+.vercel

--- a/src/module.ts
+++ b/src/module.ts
@@ -213,7 +213,7 @@ const removeCspHeaderForPrerenderedRoutes = (nuxt: Nuxt) => {
   const nitroRouteRules = nuxt.options.nitro.routeRules
   for (const route in nitroRouteRules) {
     const routeRules = nitroRouteRules[route]
-    if (routeRules.prerender) {
+    if (routeRules.prerender || nuxt.options.nitro.static) {
       routeRules.headers = routeRules.headers || {}
       routeRules.headers['Content-Security-Policy'] = ''
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Extend CSP support of SSG applications:
- parse all HTML sections
- hashes for inline styles
- hashes for external scripts
- CSP headers for static nitro presets

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR extends how we support CSP for SSG applications.

Currently, in SSG mode, Nuxt Security only searches for inline scripts in the `bodyAppend` section of Ntro's html rendering step.

With this PR, the following functionalities are added:
- Scan all sections of the `html` being rendered by Nitro. 
This covers the case where scripts or styles are added to the `<head>` tag, or to other parts of the `<body>` section.

- Scan inline styles, and add SHA hashes to the `style-src` policy. 
This covers the case where, in the absence of the `unsafe-inline` value, CSP requires that inline styles are individually authorized.

- Scan external script ressources that carry the `integrity` attribute and add SHA hashes to the `script-src` policy. 
This covers the case where an external ressource is not explicitely whitelisted (or where whitelisting is ignored by the use of `strict-dynamic`). 
In that case, CSP provides the ability to authorize an external script by its hash, provided this hash is present in its `integrity` attribute.

In addition, this PR improves SSG support for hosting providers that can automatically generate headers for static serving via their `nitro: preset` option. 
- For such hosting providers, the static server now returns HTTP headers with the correct CSP policy
- In all cases, the same policy is still being provided via the `<meta http-equiv>` tag. This ensures that, for hosting providers that cannot set HTTP headers, the static CSP policy is still being provided.

*Note: This PR does not make any change to CSP in SSR mode*

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
