### PR TITLE
feat(csp): add hashStyles option for SSG

### DIFF
--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -1,4 +1,4 @@
-import { ModuleOptions } from './types'
+import type { ModuleOptions } from './types'
 
 const defaultThrowErrorValue = { throwError: true }
 
@@ -81,6 +81,7 @@ export const defaultSecurityConfig = (serverlUrl: string): ModuleOptions => ({
     exclude: [/node_modules/, /\.git/]
   },
   ssg: {
-    hashScripts: true
+    hashScripts: true,
+    hashStyles: false
   }
 })

--- a/src/runtime/nitro/plugins/02-cspSsg.ts
+++ b/src/runtime/nitro/plugins/02-cspSsg.ts
@@ -84,7 +84,7 @@ export default defineNitroPlugin((nitroApp) => {
       // Remove '""'
       tagPolicies['script-src'] = (tagPolicies['script-src'] ?? []).concat(scriptHashes)
     }
-    if (styleHashes.length > 0 && moduleOptions.ssg?.hashScripts) {
+    if (styleHashes.length > 0 && moduleOptions.ssg?.hashStyles) {
       // Remove '""'
       tagPolicies['style-src'] = (tagPolicies['style-src'] ?? []).concat(styleHashes)
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ import type { AllowedHTTPMethods, BasicAuth, CorsOptions, RateLimiter, RequestSi
 
 export type Ssg = {
   hashScripts?: boolean;
+  hashStyles?: boolean;
 };
 
 export interface ModuleOptions {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR adds an `ssg: hashStyles` option in the `ModuleOptions` interface.

The background for this option is that CSP hashes do not carry the exact same meaning for `<script>` and for `<style>` tags.
- For the `script-src` policy, when `'strict-dynamic'` is enabled, new `<scripts>` inserted by hashed scripts will be *allowed*
- For the `style-src` policy, there is no `'strict-dynamic'` option, and therefore new `<styles>` inserted by hashed scripts will be *disallowed*.
 
As a result, a user who is not in control of how scripts dynamically insert styles, may typically want to introduce script hashes but exclude style hashes.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
