### PR TITLE
fix: csp false in rc5 removes custom csp header

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -200,6 +200,8 @@ function mergeSecurityPerRoute(nuxt: Nuxt) {
             // Because in the pre-rc1 syntax, standard headers could also be supplied in object format
             standardHeadersAsObject[optionKey] = headerValue
           }
+          // Delete security header from route rules to avoid route resolution overlaps
+          delete standardHeaders[headerName]
         }
       })
     }

--- a/src/runtime/nitro/plugins/02-securityHeaders.ts
+++ b/src/runtime/nitro/plugins/02-securityHeaders.ts
@@ -1,4 +1,4 @@
-import { getRouteRules, defineNitroPlugin, setResponseHeader, removeResponseHeader } from '#imports'
+import { getRouteRules, defineNitroPlugin, setResponseHeader } from '#imports'
 import { type OptionKey } from '../../../types/headers'
 import { getNameFromKey, headerStringFromObject } from '../../utils/headers'
 
@@ -10,10 +10,7 @@ export default defineNitroPlugin((nitroApp) => {
       Object.entries(headers).forEach(([key, optionValue]) => {
         const optionKey = key as OptionKey
         const headerName = getNameFromKey(optionKey)
-        if (optionValue === false) {
-          removeResponseHeader(event, headerName)
-        } 
-        else {
+        if (optionValue !== false) {
           const headerValue = headerStringFromObject(optionKey, optionValue)
           setResponseHeader(event, headerName, headerValue)
         }

--- a/test/fixtures/perRoute/nuxt.config.ts
+++ b/test/fixtures/perRoute/nuxt.config.ts
@@ -237,6 +237,13 @@ export default defineNuxtConfig({
         sri: false
       }
     },
+    '/preserve-middleware': {
+      security: {
+        headers: {
+          contentSecurityPolicy: false
+        }
+      }
+    },    
   },
   security: {
     headers: {

--- a/test/fixtures/perRoute/pages/preserve-middleware/deep/page.vue
+++ b/test/fixtures/perRoute/pages/preserve-middleware/deep/page.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>basic</div>
+</template>

--- a/test/fixtures/perRoute/pages/preserve-middleware/index.vue
+++ b/test/fixtures/perRoute/pages/preserve-middleware/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>basic</div>
+</template>

--- a/test/fixtures/perRoute/server/middleware/preserve-test.ts
+++ b/test/fixtures/perRoute/server/middleware/preserve-test.ts
@@ -1,0 +1,5 @@
+export default defineEventHandler((event) => {
+  if (event.path.startsWith('/preserve-middleware')) {
+    appendHeader(event, 'Content-Security-Policy', 'example')
+  }
+})

--- a/test/perRoute.test.ts
+++ b/test/perRoute.test.ts
@@ -883,6 +883,26 @@ describe('[nuxt-security] Per-route Configuration', async () => {
     expect(elementsWithIntegrity).toHaveLength(6)
   })
 
+  it ('should not remove middleware headers when false', async () => {
+    const res = await fetch('/preserve-middleware')
+    expect(res.status).toBe(200)
+    
+    const { headers } = res
+    const csp = headers.get('content-security-policy')
+    expect(csp).toBeDefined()
+    expect(csp).toBe('example')
+  })
+
+  it ('should overwrite middleware headers when not false', async () => {
+    const res = await fetch('/preserve-middleware/deep/page')
+    expect(res.status).toBe(200)
+    
+    const { headers } = res
+    const csp = headers.get('content-security-policy')
+    expect(csp).toBeDefined()
+    expect(csp).toBe("base-uri 'none'; font-src 'self' https: data:; form-action 'self'; frame-ancestors 'self'; img-src 'self' data:; object-src 'none'; script-src-attr 'none'; style-src 'self' https: 'unsafe-inline'; script-src 'self' https: 'unsafe-inline' 'strict-dynamic'; upgrade-insecure-requests;")
+  })
+
 })
 
 


### PR DESCRIPTION
Fixes #321

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR reverts a breaking change introduced by rc.5
Previously to rc.5, setting a security header value to `false` did not modify the existing header value.
With rc.5, setting a security header value to false removed the header.

We are reverting to pre-rc.5 behaviour, i.e. we semantically translate `false` to `do not set` instead of `do not send`.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
