### PR TITLE
Documentation typo change from route roules to route rules

### DIFF
--- a/docs/content/1.documentation/1.getting-started/1.setup.md
+++ b/docs/content/1.documentation/1.getting-started/1.setup.md
@@ -32,7 +32,7 @@ export default defineNuxtConfig({
 })
 ```
 
-That's it! The Nuxt Security module will now register routeRoules and middleware to make your application more secure ✨
+That's it! The Nuxt Security module will now register routeRules and middleware to make your application more secure ✨
 
 ## Configuration
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## There was a typo mistake and I tried to fix it


## Description
In Installation page below adding the module section, there is a "routeRoule" typo mistake



## Checklist:

- [x] I have updated the documentation accordingly.

