### PR TITLE
feat(ssg): disable meta tag for SSG mode

### DIFF
--- a/docs/content/1.documentation/1.getting-started/2.configuration.md
+++ b/docs/content/1.documentation/1.getting-started/2.configuration.md
@@ -116,6 +116,7 @@ security: {
     exclude: [/node_modules/, /\.git/]
   },
   ssg: {
+    enabled: true,
     hashScripts: true,
     hashStyles: false
   },

--- a/docs/content/1.documentation/2.headers/1.csp.md
+++ b/docs/content/1.documentation/2.headers/1.csp.md
@@ -155,6 +155,7 @@ export default defineNuxtConfig({
   security: {
     nonce: true, // Enables HTML nonce support in SSR mode
     ssg: {
+      enabled: true, // Enables CSP as a meta tag in SSG mode
       hashScripts: true, // Enables CSP hash support for scripts in SSG mode
       hashStyles: false // Disables CSP hash support for styles in SSG mode (recommended)
     },
@@ -263,6 +264,7 @@ export default defineNuxtConfig({
   // Global
   security: {
     ssg: {
+      enabled: true, // Enables CSP as a meta tag in SSG mode
       hashScripts: true, // Enables CSP hash support for scripts in SSG mode
       hashStyles: false // Disables CSP hash support for styles in SSG mode (recommended)
     },

--- a/docs/content/1.documentation/5.advanced/3.strict-csp.md
+++ b/docs/content/1.documentation/5.advanced/3.strict-csp.md
@@ -608,6 +608,7 @@ export default defineNuxtConfig({
   security: {
     nonce: true, // Enables HTML nonce support in SSR mode
     ssg: {
+      enabled: true, // Enables CSP as a meta tag in SSG mode
       hashScripts: true, // Enables CSP hash support for scripts in SSG mode
       hashStyles: false // Disables CSP hash support for styles in SSG mode (recommended)
     },

--- a/docs/content/1.documentation/5.advanced/3.strict-csp.md
+++ b/docs/content/1.documentation/5.advanced/3.strict-csp.md
@@ -569,7 +569,7 @@ Nuxt Security supports CSP via HTTP headers for Nitro Presets that output HTTP h
 ::alert{type="info"}
 If you deploy your SSG site on Vercel or Netlify, you will benefit automatically from CSP Headers.
 <br>
-CSP will be delivered via HTTP headers, in addition to the standard `<meta http-equiv>` approach.
+CSP will be delivered via HTTP headers, in addition to the standard `<meta http-equiv>` approach. If you want to disabled the meta tag, so that only the HTTP headers are used, you can do so with the `ssg: enabled` option.
 ::
 
 ### Per Route CSP

--- a/docs/content/1.documentation/5.advanced/3.strict-csp.md
+++ b/docs/content/1.documentation/5.advanced/3.strict-csp.md
@@ -569,7 +569,7 @@ Nuxt Security supports CSP via HTTP headers for Nitro Presets that output HTTP h
 ::alert{type="info"}
 If you deploy your SSG site on Vercel or Netlify, you will benefit automatically from CSP Headers.
 <br>
-CSP will be delivered via HTTP headers, in addition to the standard `<meta http-equiv>` approach. If you want to disabled the meta tag, so that only the HTTP headers are used, you can do so with the `ssg: enabled` option.
+CSP will be delivered via HTTP headers, in addition to the standard `<meta http-equiv>` approach. If you want to disable the meta tag, so that only the HTTP headers are used, you can do so with the `ssg: enabled` option.
 ::
 
 ### Per Route CSP

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -82,6 +82,7 @@ export const defaultSecurityConfig = (serverlUrl: string): Partial<ModuleOptions
     exclude: [/node_modules/, /\.git/]
   },
   ssg: {
+    enabled: true,
     hashScripts: true,
     hashStyles: false
   },

--- a/src/runtime/nitro/plugins/04-cspSsgHashes.ts
+++ b/src/runtime/nitro/plugins/04-cspSsgHashes.ts
@@ -25,7 +25,7 @@ export default defineNitroPlugin((nitroApp) => {
 
     // Parse HTML if SSG is enabled for this route
     if (security.ssg) {
-      const { hashScripts, hashStyles } = security.ssg
+      const { enabled, hashScripts, hashStyles } = security.ssg
 
       // Scan all relevant sections of the NuxtRenderHtmlContext
       type Section = 'body' | 'bodyAppend' | 'bodyPrepend' | 'head'
@@ -102,8 +102,10 @@ export default defineNitroPlugin((nitroApp) => {
     // Generate CSP rules
     const csp = security.headers.contentSecurityPolicy
     const headerValue = generateCspRules(csp, scriptHashes, styleHashes)
-    // Insert CSP in the http meta tag
-    html.head.push(`<meta http-equiv="Content-Security-Policy" content="${headerValue}">`)
+    // Insert CSP in the http meta tag if enabled
+    if (enabled) {
+      html.head.push(`<meta http-equiv="Content-Security-Policy" content="${headerValue}">`)
+    }
     // Update rules in HTTP header
     setResponseHeader(event, 'Content-Security-Policy', headerValue)
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ import type { SecurityHeaders } from './headers'
 import type { AllowedHTTPMethods, BasicAuth, RateLimiter, RequestSizeLimiter, XssValidator, CorsOptions } from './middlewares'
 
 export type Ssg = {
+  enabled?: boolean;
   hashScripts?: boolean;
   hashStyles?: boolean;
 };

--- a/test/fixtures/perRoute/nuxt.config.ts
+++ b/test/fixtures/perRoute/nuxt.config.ts
@@ -220,6 +220,7 @@ export default defineNuxtConfig({
       prerender: true,
       security: {
         ssg: {
+          enabled: true,
           hashScripts: true
         }
       }

--- a/test/fixtures/ssgHashes/nuxt.config.ts
+++ b/test/fixtures/ssgHashes/nuxt.config.ts
@@ -32,6 +32,7 @@ export default defineNuxtConfig({
     rateLimiter: false,
     sri: true,
     ssg: {
+      enabled: true,
       hashScripts: true,
       hashStyles: true
     }

--- a/test/fixtures/ssgHashes/nuxt.config.ts
+++ b/test/fixtures/ssgHashes/nuxt.config.ts
@@ -24,7 +24,13 @@ export default defineNuxtConfig({
     },
     '/not-ssg': {
       prerender: false
-    }
+    },
+    '/no-meta-tag': {
+      prerender: true,
+      ssg: {
+        enabled: false,
+      },
+    },
   },
 
   // Global configuration

--- a/test/fixtures/ssgHashes/pages/no-meta-tag.vue
+++ b/test/fixtures/ssgHashes/pages/no-meta-tag.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Default page
+  </div>
+</template>

--- a/test/ssgHashes.test.ts
+++ b/test/ssgHashes.test.ts
@@ -158,3 +158,22 @@ describe('[nuxt-security] SSG support of CSP', async () => {
     expect(externalStyleHashes).toBe(0)
   })
 })
+
+it('does not set CSP via meta when disabled', async () => {
+    const res = await fetch('/no-meta-tag')
+
+    const body = await res.text()
+    const { metaTag, csp, elementsWithIntegrity, inlineScriptHashes, externalScriptHashes, inlineStyleHashes, externalStyleHashes } = extractDataFromBody(body)
+
+    expect(res).toBeDefined()
+    expect(res).toBeTruthy()
+    expect(body).toBeDefined()
+    expect(metaTag).toBeNull()
+    expect(csp).toBeUndefined()
+    expect(elementsWithIntegrity).toBe(expectedIntegrityAttributes - 1) // No vue on no-meta-tag page
+    expect(inlineScriptHashes).toBe(expectedInlineScriptHashes)
+    expect(externalScriptHashes).toBe(expectedExternalScriptHashes)
+    expect(inlineStyleHashes).toBe(expectedInlineStyleHashes)
+    expect(externalStyleHashes).toBe(expectedExternalStyleHashes)
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
This PR adds a configuration option to disable the meta tag in SSG mode.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
This is useful when generating HTTP headers using a Nitro Preset, because the meta tag would be redundant and can cause errors in the console, like: `The Content Security Policy directive 'frame-ancestors' is ignored when delivered via a <meta> element.`

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
