### PR TITLE
Disable 05-cspSsgPresets

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -312,6 +312,8 @@ function registerSecurityNitroPlugins(nuxt: Nuxt, securityOptions: ModuleOptions
     )
 
     // Register nitro plugin to enable CSP Headers presets for SSG
+    // TEMPORARILY DISABLED AS NUXT 3.9.3 PREVENTS IMPORTING @NUXT/KIT IN NITRO PLUGINS
+    /*
     config.plugins.push(
       normalize(
         fileURLToPath(
@@ -319,6 +321,7 @@ function registerSecurityNitroPlugins(nuxt: Nuxt, securityOptions: ModuleOptions
         )
       )
     )
+    */
 
     // Nitro plugin to enable CSP Nonce for SSR
     config.plugins.push(

--- a/test/perRoute.test.ts
+++ b/test/perRoute.test.ts
@@ -832,10 +832,13 @@ describe('[nuxt-security] Per-route Configuration', async () => {
 
   it('does not inject CSP hashes on a deeply-disabled route', async () => {
     const res = await fetch('/csp-hash/deep/disabled')
+    // DISABLING THIS PART OF THE TEST AFTER PATCH #348 THAT REMOVES CSP SSG PRESETS
+    /*
     const cspHeaderValue = res.headers.get('content-security-policy')
     expect(cspHeaderValue).toBeDefined()
     const headerHashes = cspHeaderValue!.match(/'sha256-(.*?)'/)
     expect(headerHashes).toBeNull()
+    */
 
     const text = await res.text()
     const head = text.match(/<head>(.*?)<\/head>/s)?.[1]
@@ -849,10 +852,13 @@ describe('[nuxt-security] Per-route Configuration', async () => {
 
   it('injects CSP hashes on a deeply-enabled route', async () => {
     const res = await fetch('/csp-hash/deep/enabled')
+    // DISABLING THIS PART OF THE TEST AFTER PATCH #348 THAT REMOVES CSP SSG PRESETS
+    /*
     const cspHeaderValue = res.headers.get('content-security-policy')
     expect(cspHeaderValue).toBeDefined()
     const headerHashes = cspHeaderValue!.match(/'sha256-(.*?)'/)
     expect(headerHashes).toHaveLength(2)
+    */
 
     const text = await res.text()
     const head = text.match(/<head>(.*?)<\/head>/s)?.[1]


### PR DESCRIPTION
Fixes #348
Fixes #335

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This patch removes the cspSsgPresets functionality to temporarily solve issues #335 and #348, while we work on an alternative solution.

This patch is required after Nuxt 3.9.3 introduced protection against importing `@nuxt/kit` in Nitro plugins, which breaks `05-cspSsgPresets.ts` in our module.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
