### PR TITLE
Patch for cheerio performance

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -293,6 +293,15 @@ function registerSecurityNitroPlugins(nuxt: Nuxt, securityOptions: ModuleOptions
       )
     )
 
+    // Pre-process HTML into DOM tree
+    config.plugins.push(
+      normalize(
+        fileURLToPath(
+          new URL('./runtime/nitro/plugins/02a-preprocessHtml', import.meta.url)
+        )
+      )
+    )
+
     // Register nitro plugin to enable Subresource Integrity
     config.plugins.push(
       normalize(
@@ -328,6 +337,16 @@ function registerSecurityNitroPlugins(nuxt: Nuxt, securityOptions: ModuleOptions
       normalize(
         fileURLToPath(
           new URL('./runtime/nitro/plugins/99-cspSsrNonce', import.meta.url)
+        )
+      )
+    )
+
+
+    // Recombine HTML from DOM tree
+    config.plugins.push(
+      normalize(
+        fileURLToPath(
+          new URL('./runtime/nitro/plugins/99b-recombineHtml', import.meta.url)
         )
       )
     )

--- a/src/runtime/nitro/plugins/02a-preprocessHtml.ts
+++ b/src/runtime/nitro/plugins/02a-preprocessHtml.ts
@@ -1,0 +1,24 @@
+import { defineNitroPlugin, getRouteRules } from '#imports'
+import * as cheerio from 'cheerio'
+
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('render:html', async (html, { event }) => {
+
+    // Exit if no need to parse HTML for this route
+    const { security } = getRouteRules(event)
+    if (!security?.sri && (!security?.headers || !security?.headers.contentSecurityPolicy)) {
+      return
+    }
+
+    type Section = 'body' | 'bodyAppend' | 'bodyPrepend' | 'head'
+    const sections = ['body', 'bodyAppend', 'bodyPrepend', 'head'] as Section[]
+    const cheerios = {} as Record<Section, ReturnType<typeof cheerio.load>[]>
+    for (const section of sections) {
+      cheerios[section] = html[section].map(element => {
+        return cheerio.load(element, null, false)
+      })
+    }
+    event.context.cheerios = cheerios
+  })
+})

--- a/src/runtime/nitro/plugins/03-subresourceIntegrity.ts
+++ b/src/runtime/nitro/plugins/03-subresourceIntegrity.ts
@@ -1,10 +1,10 @@
 import { useStorage, defineNitroPlugin, getRouteRules } from '#imports'
-import * as cheerio from 'cheerio'
 import { isPrerendering } from '../utils'
+import { type CheerioAPI } from 'cheerio'
+
 
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('render:html', async (html, { event }) => {
-
     // Exit if SRI not enabled for this route
     const { security } = getRouteRules(event)
     if (!security?.sri) {
@@ -29,10 +29,9 @@ export default defineNitroPlugin((nitroApp) => {
     // However the SRI standard provides that other elements may be added to that list in the future
     type Section = 'body' | 'bodyAppend' | 'bodyPrepend' | 'head'
     const sections = ['body', 'bodyAppend', 'bodyPrepend', 'head'] as Section[]
+    const cheerios = event.context.cheerios as Record<Section, CheerioAPI[]>
     for (const section of sections) {
-      html[section] = html[section].map(element => {
-        
-        const $ = cheerio.load(element, null, false)
+      cheerios[section].forEach($ => {
         // Add integrity to all relevant script tags
         $('script').each((i, script) => {
           const scriptAttrs = $(script).attr()
@@ -68,7 +67,6 @@ export default defineNitroPlugin((nitroApp) => {
             }
           }
         })
-        return $.html()
       })
     }
   })

--- a/src/runtime/nitro/plugins/99-cspSsrNonce.ts
+++ b/src/runtime/nitro/plugins/99-cspSsrNonce.ts
@@ -1,5 +1,5 @@
 import { defineNitroPlugin, getRouteRules, setResponseHeader } from '#imports'
-import * as cheerio from 'cheerio'
+import { type CheerioAPI } from 'cheerio'
 import type { ContentSecurityPolicyValue } from '~/src/module'
 import { headerStringFromObject } from '../../utils/headers'
 import { isPrerendering } from '../utils'
@@ -26,16 +26,15 @@ export default defineNitroPlugin((nitroApp) => {
       // Scan all relevant sections of the NuxtRenderHtmlContext
       type Section = 'body' | 'bodyAppend' | 'bodyPrepend' | 'head'
       const sections = ['body', 'bodyAppend', 'bodyPrepend', 'head'] as Section[]
+      const cheerios = event.context.cheerios as Record<Section, CheerioAPI[]>
       for (const section of sections) {
-        html[section] = html[section].map(element => {
-          const $ = cheerio.load(element, null, false)
+        cheerios[section].forEach($ => {
           // Add nonce to all link tags
           $('link').attr('nonce', nonce)
           // Add nonce to all script tags
           $('script').attr('nonce', nonce)
           // Add nonce to all style tags
           $('style').attr('nonce', nonce)
-          return $.html()
         })
       }
     }

--- a/src/runtime/nitro/plugins/99b-recombineHtml.ts
+++ b/src/runtime/nitro/plugins/99b-recombineHtml.ts
@@ -1,0 +1,25 @@
+import { defineNitroPlugin, getRouteRules } from '#imports'
+import { type CheerioAPI } from 'cheerio'
+
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('render:html', (html, { event }) => {
+
+    // Exit if no need to parse HTML for this route
+    const { security } = getRouteRules(event)
+    if (!security?.sri && (!security?.headers || !security.headers.contentSecurityPolicy)) {
+      return
+    }
+
+    // Scan all relevant sections of the NuxtRenderHtmlContext
+    type Section = 'body' | 'bodyAppend' | 'bodyPrepend' | 'head'
+    const sections = ['body', 'bodyAppend', 'bodyPrepend', 'head'] as Section[]
+    const cheerios = event.context.cheerios as Record<Section, CheerioAPI[]>
+    for (const section of sections) {
+      html[section] = cheerios[section].map($ => {
+        const html = $.html()
+        return html
+      })
+    }
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Fixes #341

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This is a first pass at mitigating cheerio performance issues reported in #341.
Instead of parsing and recombining multiple times the same HTML, we now parse it only once upfront, and recombine it at the end.

It is unlikely to be the best approach as we may prefer to not use Cheerio anymore and instead re-implement via regexes.
I'm proposing this patch as a quick fix in the meantime so that Cloudflare users can mitigate issues.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
