### PR TITLE
Further optimization patch for cheerio

### DIFF
--- a/src/runtime/nitro/plugins/02a-preprocessHtml.ts
+++ b/src/runtime/nitro/plugins/02a-preprocessHtml.ts
@@ -1,5 +1,5 @@
 import { defineNitroPlugin, getRouteRules } from '#imports'
-import * as cheerio from 'cheerio'
+import * as cheerio from 'cheerio/lib/slim'
 
 
 export default defineNitroPlugin((nitroApp) => {
@@ -16,7 +16,12 @@ export default defineNitroPlugin((nitroApp) => {
     const cheerios = {} as Record<Section, ReturnType<typeof cheerio.load>[]>
     for (const section of sections) {
       cheerios[section] = html[section].map(element => {
-        return cheerio.load(element, null, false)
+        return cheerio.load(element, {
+          xml: {
+            // Disable `xmlMode` to parse HTML with htmlparser2.
+            xmlMode: false,
+          },
+        }, false)
       })
     }
     event.context.cheerios = cheerios


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Fixes #341 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This is an additional patch to again improve Cheerio. Following review of Cheerio's documentation, we now
- use the htmlparser-2 option instead of parse5
- load the slim version of cheerio

This is the second optimization patch related to Cheerio performance issues reported in #341 

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
