### PR TITLE
fix: add explicit imports for setHeader and removeResponseHeader in 00-context.ts

### DIFF
--- a/src/runtime/nitro/plugins/00-context.ts
+++ b/src/runtime/nitro/plugins/00-context.ts
@@ -1,6 +1,6 @@
 import { getNameFromKey, headerStringFromObject} from "../../utils/headers"
 import { createRouter} from "radix3"
-import { defineNitroPlugin } from '#imports'
+import { defineNitroPlugin, setHeader, removeResponseHeader} from "#imports"
 import { OptionKey } from "~/src/module"
 
 export default defineNitroPlugin((nitroApp) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Fixes my issue https://github.com/Baroshem/nuxt-security/issues/373

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
It seems like not explicitly importing setHeader (and i assume also removeResponseHeader)
prevents them from beeing in the output of the nuxt build.
<!--- Why is this change required? What problem does it solve? -->
It solved the issue that setting the headers via a nitro plugin with the hook 'nuxt-security:headers' does not work.
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Resolves: #373

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
I have not added tests, since it is only a missing import
