### PR TITLE
feat: add escapeHtml option to XssValidator

### DIFF
--- a/docs/content/1.documentation/3.middleware/3.xss-validator.md
+++ b/docs/content/1.documentation/3.middleware/3.xss-validator.md
@@ -48,6 +48,7 @@ XSS validator accepts following configuration options:
 ```ts
 type XssValidator = {
   whiteList: Record<string, any>;
+  escapeHtml: boolean;
   stripIgnoreTag: boolean;
   stripIgnoreTagBody: boolean;
   css: Record<string, any> | boolean;

--- a/src/runtime/server/middleware/xssValidator.ts
+++ b/src/runtime/server/middleware/xssValidator.ts
@@ -1,11 +1,15 @@
-import { FilterXSS } from 'xss'
+import { FilterXSS, IFilterXSSOptions } from 'xss'
 import { defineEventHandler, createError, getQuery, readBody, getRouteRules } from '#imports'
 
 export default defineEventHandler(async (event) => {
   const { security } = getRouteRules(event)
 
   if (security?.xssValidator) {
-    const xssValidator = new FilterXSS(security.xssValidator)
+    const filterOpt: IFilterXSSOptions = { ...security.xssValidator, escapeHtml: undefined }
+    if (security.xssValidator.escapeHtml === false) { // No html escaping (by default "<" is replaced by "&lt;" and ">" by "&gt;")
+      filterOpt.escapeHtml = (value: string) => value
+    }
+    const xssValidator = new FilterXSS(filterOpt)
 
     if (event.node.req.socket.readyState !== 'readOnly') {
       if (['POST', 'GET'].includes(event.node.req.method!)) {

--- a/src/types/middlewares.ts
+++ b/src/types/middlewares.ts
@@ -17,6 +17,7 @@ export type RateLimiter = {
 
 export type XssValidator = {
   whiteList?: Record<string, any>;
+  escapeHtml?: boolean;
   stripIgnoreTag?: boolean;
   stripIgnoreTagBody?: boolean;
   css?: Record<string, any> | boolean;


### PR DESCRIPTION
resolves #206


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
js-xss has [`escapeHtml`option](https://github.com/leizongmin/js-xss/blob/master/lib/index.js#L18), [by default](https://github.com/leizongmin/js-xss/blob/master/lib/default.js#L158) `<` is replaced by `&lt;` and `>` by `&gt;`
This pull request allows dev to easily disable this feature

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

### To test
Before this fail:
```js
fetch('/api/test', { method: 'POST', body: JSON.stringify({ value: "ok ->" }), headers: { 'Content-Type': 'application/json' } })
```
Now, if `xssValidator.escapeHtml` is set to false it works