### PR TITLE
fix(ssg): generate meta tag without html,head,body tags

### DIFF
--- a/src/runtime/nitro/plugins/04-cspSsgHashes.ts
+++ b/src/runtime/nitro/plugins/04-cspSsgHashes.ts
@@ -103,7 +103,7 @@ export default defineNitroPlugin((nitroApp) => {
     const headerValue = generateCspRules(csp, scriptHashes, styleHashes)
     // Insert CSP in the http meta tag if meta is true
     if (security.ssg?.meta) {
-      cheerios.head.push(cheerio.load(`<meta http-equiv="Content-Security-Policy" content="${headerValue}">`))
+      cheerios.head.push(cheerio.load(`<meta http-equiv="Content-Security-Policy" content="${headerValue}">`, null, false))
     }
     // Update rules in HTTP header
     setResponseHeader(event, 'Content-Security-Policy', headerValue)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
By default `cheerio.load` will introduce `<html>`, `<head>` and `<body>` elements if they are not present in the argument. This causes the following code to add duplicate `<html>`, `<head>` and `<body>` elements inside the already existing `<head>`.

See [their docs](https://cheerio.js.org/docs/basics/loading#load).

This PR fixes this by disabling the default behaviour of the load function.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
