### PR TITLE
fix(ssg): remove frame-ancestors from meta

### DIFF
--- a/src/runtime/nitro/plugins/04-cspSsgHashes.ts
+++ b/src/runtime/nitro/plugins/04-cspSsgHashes.ts
@@ -102,7 +102,7 @@ export default defineNitroPlugin((nitroApp) => {
     const csp = security.headers.contentSecurityPolicy
     const headerValue = generateCspRules(csp, scriptHashes, styleHashes)
     // Insert CSP in the http meta tag if meta is true
-    if (security.ssg?.meta) {
+    if (security.ssg && security.ssg.meta) {
       cheerios.head.push(cheerio.load(`<meta http-equiv="Content-Security-Policy" content="${headerValue}">`))
     }
     // Update rules in HTTP header
@@ -111,28 +111,33 @@ export default defineNitroPlugin((nitroApp) => {
 
   // Insert hashes in the CSP meta tag for both the script-src and the style-src policies
   function generateCspRules(csp: ContentSecurityPolicyValue, scriptHashes: Set<string>, styleHashes: Set<string>) {
-    const generatedCsp = Object.fromEntries(Object.entries(csp).map(([key, value]) => {
-      // Return boolean values unchanged
-      if (typeof value === 'boolean') {
-        return [key, value]
-      }
+    const generatedCsp = <ContentSecurityPolicyValue>Object.fromEntries(
+      Object.entries(csp)
+      .map(([key, value]) => {
+        // Return boolean values unchanged
+        if (typeof value === 'boolean') {
+          return [key, value]
+        }
 
-      // Make sure nonce placeholders are eliminated
-      const sources = (typeof value === 'string') ? value.split(' ').map(token => token.trim()).filter(token => token) : value
-      const modifiedSources = sources.filter(source => !source.startsWith("'nonce-"))
+        // Make sure nonce placeholders are eliminated
+        const sources = (typeof value === 'string') ? value.split(' ').map(token => token.trim()).filter(token => token) : value
+        const modifiedSources = sources.filter(source => !source.startsWith("'nonce-"))
 
-      const directive = key as keyof ContentSecurityPolicyValue
-      // Add hashes to script and style
-      if (directive === 'script-src') {
-        modifiedSources.push(...scriptHashes)
-        return [directive, modifiedSources]
-      } else if (directive === 'style-src') {
-        modifiedSources.push(...styleHashes)
-        return [directive, modifiedSources]
-      } else {
-        return [directive, modifiedSources]
-      }
-    })) as ContentSecurityPolicyValue
+        const directive = <keyof ContentSecurityPolicyValue>key
+        // Add hashes to script and style
+        if (directive === 'script-src') {
+          modifiedSources.push(...scriptHashes)
+          return [directive, modifiedSources]
+        } else if (directive === 'style-src') {
+          modifiedSources.push(...styleHashes)
+          return [directive, modifiedSources]
+        } else {
+          return [directive, modifiedSources]
+        }
+      })
+      // Remove frame-ancestors from the CSP when delivered in the meta tag
+      .filter(([key]) => <keyof ContentSecurityPolicyValue>key !== 'frame-ancestors')
+    )
     return headerStringFromObject('contentSecurityPolicy', generatedCsp)
   }
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Closes #329 


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Removes the `frame-ancestors` CSP directive in SSG mode.
As stated in the [MDN Doc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors), this directive is not supported in the meta element.

Fixes Chrome complaining of the same:
![Capture d’écran 2024-02-25 à 11 31 19](https://github.com/Baroshem/nuxt-security/assets/7295259/0be1c3ef-44e4-4c8d-9375-58a1c38c7ed4)


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
