### PR TITLE
fix(core): do not decode entities in HTML

### DIFF
--- a/src/runtime/nitro/plugins/02a-preprocessHtml.ts
+++ b/src/runtime/nitro/plugins/02a-preprocessHtml.ts
@@ -20,6 +20,7 @@ export default defineNitroPlugin((nitroApp) => {
           xml: {
             // Disable `xmlMode` to parse HTML with htmlparser2.
             xmlMode: false,
+            decodeEntities: false
           },
         }, false)
       })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Fixes #393

Currently, cheerio uses the default setting of `decodeEntities: true` when parsing the HTML document.
This modifies the encoding of special characters (e.g. German umlauts).
This PR changes the option to `decodeEntities: false`, which prevents cheerio from modifying the original source.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
