### PR TITLE
fix: set nonce in response headers instead of using configuration

### DIFF
--- a/src/runtime/nitro/plugins/99-cspSsrNonce.ts
+++ b/src/runtime/nitro/plugins/99-cspSsrNonce.ts
@@ -1,7 +1,7 @@
 import { defineNitroPlugin, getRouteRules, setResponseHeader } from '#imports'
 import { type CheerioAPI } from 'cheerio'
 import { isPrerendering } from '../utils'
-import { H3Event } from "h3"
+import type { H3Event } from "h3"
 
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('render:html', (html, { event }) => {

--- a/src/runtime/nitro/plugins/99-cspSsrNonce.ts
+++ b/src/runtime/nitro/plugins/99-cspSsrNonce.ts
@@ -1,9 +1,7 @@
 import { defineNitroPlugin, getRouteRules, setResponseHeader } from '#imports'
 import { type CheerioAPI } from 'cheerio'
-import type { ContentSecurityPolicyValue } from '~/src/module'
-import { headerStringFromObject } from '../../utils/headers'
 import { isPrerendering } from '../utils'
-
+import { H3Event } from "h3"
 
 export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('render:html', (html, { event }) => {
@@ -21,7 +19,7 @@ export default defineNitroPlugin((nitroApp) => {
     let nonce: string | undefined;
 
     // Parse HTML if nonce is enabled for this route
-    if (security.nonce) { 
+    if (security.nonce) {
       nonce = event.context.nonce as string
       // Scan all relevant sections of the NuxtRenderHtmlContext
       type Section = 'body' | 'bodyAppend' | 'bodyPrepend' | 'head'
@@ -39,37 +37,34 @@ export default defineNitroPlugin((nitroApp) => {
       }
     }
 
-    // Generate CSP rules
-    const csp = security.headers.contentSecurityPolicy
-    const headerValue = generateCspRules(csp, nonce)
+  })
 
-    // Update rules in HTTP header
-    setResponseHeader(event, 'Content-Security-Policy', headerValue)
+  nitroApp.hooks.hook('beforeResponse', (event) => {
+    const nonce = event.context.nonce as string
+    // Exit if no CSP defined
+    const { security } = getRouteRules(event)
+    if (!security?.headers || !security.headers.contentSecurityPolicy) {
+      return
+    }
+
+    setNonceInCsp(event, nonce)
   })
 
   // Insert hashes in the CSP meta tag for both the script-src and the style-src policies
-  function generateCspRules(csp: ContentSecurityPolicyValue, nonce?: string) {
-    const generatedCsp = Object.fromEntries(Object.entries(csp).map(([key, value]) => {
-      // Return boolean values unchanged
-      if (typeof value === 'boolean') {
-        return [key, value]
-      }
-      // Make sure nonce placeholders are eliminated
-      const sources = (typeof value === 'string') ? value.split(' ').map(token => token.trim()).filter(token => token) : value
-      const modifiedSources = sources
-        .filter(source => !source.startsWith("'nonce-") || source === "'nonce-{{nonce}}'")
-        .map(source => {
-          if (source === "'nonce-{{nonce}}'") {
-            return nonce ? `'nonce-${nonce}'` : ''
-          } else {
-            return source
-          }
-        })
-        .filter(source => source)
-
-      const directive = key as keyof ContentSecurityPolicyValue
-      return [directive, modifiedSources]
-    })) as ContentSecurityPolicyValue
-    return headerStringFromObject('contentSecurityPolicy', generatedCsp)
+  function setNonceInCsp(event: H3Event, nonce?: string) {
+    const headers = getResponseHeaders(event)
+    if (!headers['content-security-policy']) {
+      return
+    }
+    const newCspHeader = headers['content-security-policy'].split('; ').map(token => token.split(' ').filter(source => !source.startsWith("'nonce-") || source === "'nonce-{{nonce}}'")
+      .map(source => {
+        source = source.trim()
+        if (source === "'nonce-{{nonce}}'") {
+          return nonce ? `'nonce-${nonce}'` : ''
+        } else {
+          return source
+        }
+      }).filter(source => source).join(' ')).join('; ')
+    setResponseHeader(event, 'Content-Security-Policy', newCspHeader)
   }
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Fix #407 

Hey :wave: 
This PR change the way the SSR CSP plugin works. Before that, it was relying on the configuration. 

This Pr moves the replacement of the nonce placeholder to `beforeResponse`, so it can parse and rewrite the content security policy header after it was set (by runtime hooks and the security configuration/build-time config)

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
