### PR TITLE
feat(core): use virtual file system for SRI

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -2,6 +2,7 @@ import { defineNuxtConfig } from 'nuxt/config'
 
 export default defineNuxtConfig({
   modules: ['../src/module'],
+  devtools: { enabled: true },
 
   // Per route configuration
   routeRules: {
@@ -46,6 +47,7 @@ export default defineNuxtConfig({
   // Global configuration
   security: {
     headers: {
+      crossOriginEmbedderPolicy: false,
       xXSSProtection: '0'
     },
     rateLimiter: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -195,8 +195,15 @@ export default defineNuxtModule<ModuleOptions>({
     // Import composables
     addImportsDir(resolver.resolve('./runtime/composables'))
 
-    // Calculates SRI hashes at build time
-    nuxt.hook('nitro:build:before', hashBundledAssets)
+    // Record SRI Hashes in the Virtual File System at build time
+    let sriHashes: Record<string, string> = {}
+    nuxt.options.nitro.virtual = defu(
+      { '#sri-hashes': () => `export default ${JSON.stringify(sriHashes)}` },
+      nuxt.options.nitro.virtual
+    )
+    nuxt.hook('nitro:build:before', async(nitro) => {
+      sriHashes = await hashBundledAssets(nitro)
+    })
   }
 })
 

--- a/src/runtime/utils/hashes.ts
+++ b/src/runtime/utils/hashes.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises'
+import { readdir, readFile } from 'node:fs/promises'
 import type { Nitro } from 'nitropack'
 import { join } from 'pathe'
 
@@ -47,18 +47,7 @@ export async function hashBundledAssets(nitro: Nitro) {
       }
     }
   }
-
-  // Save hashes in a /integrity directory within the .nuxt build for later use with SSG
-  const buildDir = nitro.options.buildDir
-  const integrityDir = join(buildDir, 'integrity')
-  if (!existsSync(integrityDir)) {
-    await mkdir(integrityDir)
-  }
-  const hashFilePath = join(integrityDir, 'sriHashes.json')
-  await writeFile(hashFilePath, JSON.stringify(sriHashes))
-
-  // Mount the /integrity directory into server assets for later use with SSR
-  nitro.options.serverAssets.push({ dir: integrityDir, baseName: 'integrity' })
+  return sriHashes
 }
 
 export function generateHash (content: Buffer | string, hashAlgorithm: string) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR brings a technical rewrite of the way we save SRI hashes at build time.

Previously, the way we saved SRI hashes was hacky. We were writing the hashes on the drive under the `.nuxt` build-time directory, which was necessary for SSG rendering of integrity hashes. But because this directory is not available in the server context in SSR mode, we also copied them to the server assets output folder. Then we relied on `useStorage` to retrieve the hashes, and depending whether the context was SSR or SSG, we had to look either into the `build` folder or `assets` folder. Because the output was in JSON format, we encountered issues when Nitropack changed the format of raw assets in JSON format (most notably #395).

With this rewrite, we now use the native Nuxt Virtual File System to inject SRI hashes at build time. In practice, this means that the SRI hashes are now directly bundled into the Nitro server runtime. We do not need `useStorage` to read them from the disk anymore.

This closes #395 definitively as we remove the dependency from `useStorage` raw format.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
