### PR TITLE
fix(csp): ensure charset meta at top of head

### DIFF
--- a/src/runtime/nitro/plugins/60-recombineHtml.ts
+++ b/src/runtime/nitro/plugins/60-recombineHtml.ts
@@ -32,7 +32,14 @@ export default defineNitroPlugin((nitroApp) => {
       const csp = structuredClone(rules.headers.contentSecurityPolicy)
       csp['frame-ancestors'] = false
       const headerValue = headerStringFromObject('contentSecurityPolicy', csp)
-      html.head.unshift(`<meta http-equiv="Content-Security-Policy" content="${headerValue}">`)
+
+      // Let's insert the CSP meta tag just after the first tag which should be the charset meta
+      let insertIndex = 0
+      const metaCharsetMatch = html.head[0].match(/^<meta charset="(.*?)">/mdi)
+      if (metaCharsetMatch && metaCharsetMatch.indices) {
+        insertIndex = metaCharsetMatch.indices[0][1]
+      }
+      html.head[0] = html.head[0].slice(0, insertIndex) + `<meta http-equiv="Content-Security-Policy" content="${headerValue}">` + html.head[0].slice(insertIndex) 
     }
   })
 })

--- a/test/ssgHashes.test.ts
+++ b/test/ssgHashes.test.ts
@@ -217,4 +217,15 @@ describe('[nuxt-security] SSG support of CSP', async () => {
     const metaFrameAncestors = metaCsp!.split(';').find(policy => policy.trim().startsWith('frame-ancestors'))
     expect(metaFrameAncestors).toBeUndefined()
   })
+
+  it('sets CSP meta at top of head after charset meta', async () => {
+    const res = await fetch('/')
+
+    const body = await res.text()
+
+    expect(res).toBeDefined()
+    expect(res).toBeTruthy()
+    expect(body).toBeDefined()
+    expect(body).toMatch(/^<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy"/)
+  })
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
Closes #444

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Currently we insert the CSP meta tag as the first element, to make sure it is read by the UA as soon as possible.

However the [W3C spec for HTML5](https://html.spec.whatwg.org/multipage/semantics.html#charset) mentions that the charset meta tag should be the first in `head`

This PR ensures that the CSP meta tag is inserted right after the charset meta tag, if it exists.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
