### PR TITLE
fix(core): spread storage options

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -211,12 +211,12 @@ function registerRateLimiterStorage(nuxt: Nuxt, securityOptions: ModuleOptions) 
       securityOptions.rateLimiter ? securityOptions.rateLimiter.driver : undefined,
       { name: 'lruCache' }
     )
-    const { name, options } = driver
+    const { name, options = {} } = driver
     config.storage = defu(
       {
         '#rate-limiter-storage': {
           driver: name,
-          options
+          ...options
         }
       },
       config.storage

--- a/src/types/middlewares.ts
+++ b/src/types/middlewares.ts
@@ -1,16 +1,18 @@
+import type { BuiltinDriverName, BuiltinDriverOptions } from 'unstorage'
 export type RequestSizeLimiter = {
   maxRequestSizeInBytes: number;
   maxUploadFileRequestInBytes: number;
   throwError?: boolean;
 };
 
-export type RateLimiter = {
+export type RateLimiter<T extends BuiltinDriverName = BuiltinDriverName> = {
   tokensPerInterval: number;
   interval: string | number;
   driver?: {
-    name: string,
-    options?: Record<string, any>
-  }
+    [K in T]: { 
+      name: K; 
+      options?:  BuiltinDriverOptions[K] }
+  }[T];
   headers?: boolean;
   throwError?: boolean;
 };

--- a/test/fixtures/storageOptions/app.vue
+++ b/test/fixtures/storageOptions/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/storageOptions/nuxt.config.ts
+++ b/test/fixtures/storageOptions/nuxt.config.ts
@@ -1,0 +1,17 @@
+export default defineNuxtConfig({
+  modules: [
+    '../../../src/module'
+  ],
+  security: {
+    rateLimiter: {
+      tokensPerInterval: 3,
+      interval: 1000000,
+      driver: { 
+        name: 'fsLite',
+        options: {
+          base: './test/fixtures/storageOptions/.nuxt/test/.data/db'
+        }
+      }
+    }
+  }
+})

--- a/test/fixtures/storageOptions/package.json
+++ b/test/fixtures/storageOptions/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "basic",
+  "type": "module"
+}

--- a/test/fixtures/storageOptions/pages/index.vue
+++ b/test/fixtures/storageOptions/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>basic</div>
+</template>

--- a/test/storageOptions.test.ts
+++ b/test/storageOptions.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { rm } from 'node:fs/promises'
+import { setup, fetch } from '@nuxt/test-utils'
+
+describe('[nuxt-security] Storage options', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/storageOptions', import.meta.url)),
+  })
+
+  const dbPath = './test/fixtures/storageOptions/.nuxt/test/.data/db'
+  await rm(dbPath, { recursive: true, force: true })
+
+  it('should pass options to a custom driver', async () => {
+    const res1 = await fetch('/')
+    const res2 = await fetch('/')
+
+    expect(res1).toBeDefined()
+    expect(res1).toBeTruthy()
+    expect(res2.status).toBe(200)
+    expect(res2.statusText).toBe('OK')
+  })
+
+  it('should return 429 with the custom driver', async () => {
+    const res1 = await fetch('/')
+    await fetch('/')
+    await fetch('/')
+    await fetch('/')
+    const res5 = await fetch('/')
+
+    expect(res1).toBeDefined()
+    expect(res1).toBeTruthy()
+    expect(res5.status).toBe(429)
+    expect(res5.statusText).toBe('Too Many Requests')
+  })
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Closes #433

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

The Rate Limiter options need to be spread in order to support all the `unstorage` drivers.

Previously, only the `options` property could be provided to the underlying driver, because this driver has only one property with the name `options`.

With this PR, any property name can be provided under the `options` property.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
