### PR TITLE
fix: remove navigate-to csp directive

### DIFF
--- a/docs/content/1.documentation/2.headers/1.csp.md
+++ b/docs/content/1.documentation/2.headers/1.csp.md
@@ -75,7 +75,6 @@ contentSecurityPolicy: {
   'sandbox'?: CSPSandboxValue[] | false;
   'form-action'?: CSPSourceValue[] | false;
   'frame-ancestors'?: ("'self'" | "'none'" | string)[] | false;
-  'navigate-to'?: ("'self'" | "'none'" | "'unsafe-allow-redirects'" | string)[] | false;
   'report-uri'?: string[] | false;
   'report-to'?: string | false;
   'upgrade-insecure-requests'?: boolean;

--- a/src/types/headers.ts
+++ b/src/types/headers.ts
@@ -82,7 +82,8 @@ export type ContentSecurityPolicyValue = {
   'sandbox'?: CSPSandboxValue[] | string | false;
   'form-action'?: CSPSourceValue[] | string | false;
   'frame-ancestors'?: ("'self'" | "'none'" | string)[] | string | false;
-  'navigate-to'?: ("'self'" | "'none'" | "'unsafe-allow-redirects'" | string)[] | string | false;
+  // See https://github.com/w3c/webappsec-csp/pull/564
+  //'navigate-to'?: ("'self'" | "'none'" | "'unsafe-allow-redirects'" | string)[] | string | false;
   'report-uri'?: string[] | string | false;
   'report-to'?: string | false;
   'upgrade-insecure-requests'?: boolean;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
The navigate-to directive was removed from the CSP spec, and is therefore not needed to be configurable. This comments it out so in case a new version of it resurfaces it could easily be added back.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
