### PR TITLE
feat(csp): support style nonce in development

### DIFF
--- a/docs/content/1.documentation/2.headers/1.csp.md
+++ b/docs/content/1.documentation/2.headers/1.csp.md
@@ -217,15 +217,6 @@ export default defineNuxtConfig({
 - `"'nonce-{{nonce}}'"` placeholder: Include this value in any individual policy that you want to be governed by nonce. 
 
 
-::alert{type="warning"}
-Our default recommendation is to avoid using the `"'nonce-{{nonce}}'"` placeholder on `style-src` policy.
-<br>
-⚠ This is because Nuxt's mechanism for Client-Side hydration of styles could be blocked by CSP in that case.
-<br>
-For further discussion and alternatives, please refer to our [Advanced Section on Strict CSP](/documentation/advanced/strict-csp).
-::
-
-
 _Note: Nonce only works for SSR. The `nonce` option and the `"'nonce-{{nonce}}'"` placeholders are ignored when you build your app for SSG via `nuxi generate`._
 
 
@@ -305,28 +296,6 @@ Please see below our section on [Integrity Hashes For SSG](#integrity-hashes-for
 
 _Note: Hashes only work for SSG. The `ssg` options are ignored when you build your app for SSR via `nuxi build`._
 
-
-
-## Hot reload during development
-
-If you have enabled `nonce-{{nonce}}` on `style-src`, you will need to disable it in order to allow hot reloading during development.
-
-```ts
-export default defineNuxtConfig({
-  security: {
-    nonce: true,
-    headers: {
-      contentSecurityPolicy: {
-        'style-src': process.env.NODE_ENV === 'development' ? 
-        ["'self'", "'unsafe-inline'"] :
-        ["'self'", "'unsafe-inline'", "nonce-{{nonce}}"]
-      }
-    }
-  }
-})
-```
-
-Note that this is not necessary if you use our default configuration settings.
 
 ## Per-route configuration
 

--- a/src/runtime/nitro/plugins/40-cspSsrNonce.ts
+++ b/src/runtime/nitro/plugins/40-cspSsrNonce.ts
@@ -53,5 +53,12 @@ export default defineNitroPlugin((nitroApp) => {
         return element
       })
     }
+
+    // Add meta header for Vite in development
+    if (import.meta.dev) {
+      html.head.push(
+        `<meta property="csp-nonce" nonce="${nonce}">`,
+      )
+    }
   })
 })


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description

Allows to use `"'nonce-{{nonce}}'"` placeholder on `style-src` policy in development.
Resolves discussion #454.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

Not sure how to run tests for development mode.