### PR TITLE
fix(csp): inline script/style have whitespace character

### DIFF
--- a/src/runtime/nitro/plugins/30-cspSsgHashes.ts
+++ b/src/runtime/nitro/plugins/30-cspSsgHashes.ts
@@ -4,8 +4,8 @@ import { generateHash } from '../../../utils/hash'
 import type { Section } from '../../../types/module'
 
 
-const INLINE_SCRIPT_RE = /<script(?![^>]*?\bsrc="[\w:.\-\\/]+")[^>]*>(.*?)<\/script>/gi
-const STYLE_RE = /<style[^>]*>(.*?)<\/style>/gi
+const INLINE_SCRIPT_RE = /<script(?![^>]*?\bsrc="[\w:.\-\\/]+")[^>]*>([\s\S]*?)<\/script>/gi
+const STYLE_RE = /<style[^>]*>([\s\S]*?)<\/style>/gi
 const SCRIPT_RE = /<script(?=[^>]+\bsrc="[^"]+")(?=[^>]+\bintegrity="([\w\-+/=]+)")[^>]+(?:\/>|><\/script[^>]*?>)/gi
 const LINK_RE = /<link(?=[^>]+\brel="(stylesheet|preload|modulepreload)")(?=[^>]+\bintegrity="([\w\-+/=]+)")(?=(?:[^>]+\bas="(\w+)")?)[^>]+>/gi
 

--- a/test/fixtures/ssgHashes/nuxt.config.ts
+++ b/test/fixtures/ssgHashes/nuxt.config.ts
@@ -9,7 +9,13 @@ export default defineNuxtConfig({
     '/inline-script': {
       prerender: true
     },
+    '/inline-script-with-linebreak': {
+      prerender: true
+    },
     '/inline-style': {
+      prerender: true
+    },
+    '/inline-style-with-linebreak': {
       prerender: true
     },
     '/external-script': {

--- a/test/fixtures/ssgHashes/pages/inline-script-with-linebreak.vue
+++ b/test/fixtures/ssgHashes/pages/inline-script-with-linebreak.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>Default page</div>
+</template>
+<script setup>
+useHead({
+  script: [
+    {
+      textContent: `
+      
+      
+      window.myImportantVar = 1
+      
+      
+      `,
+      type: 'text/javascript'
+    }
+  ]
+})
+</script>

--- a/test/fixtures/ssgHashes/pages/inline-style-with-linebreak.vue
+++ b/test/fixtures/ssgHashes/pages/inline-style-with-linebreak.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>Default page</div>
+</template>
+<script setup>
+useHead({
+  style: [
+    {
+      textContent: `
+      div { color: blue }
+      `,
+      type: 'text/css'
+    }
+  ]
+})
+</script>

--- a/test/ssgHashes.test.ts
+++ b/test/ssgHashes.test.ts
@@ -84,8 +84,43 @@ describe('[nuxt-security] SSG support of CSP', async () => {
     expect(externalStyleHashes).toBe(expectedExternalStyleHashes)
   })
 
+  it('sets script-src for inline scripts with line break', async () => {
+    const res = await fetch('/inline-script-with-linebreak')
+    const body = await res.text()
+    const { metaTag, csp, elementsWithIntegrity, inlineScriptHashes, externalScriptHashes, inlineStyleHashes, externalStyleHashes } = extractDataFromBody(body)
+    
+    expect(res).toBeDefined()
+    expect(res).toBeTruthy()
+    expect(body).toBeDefined()
+    expect(metaTag).toBeDefined()
+    expect(csp).toBeDefined()
+    expect(elementsWithIntegrity).toBe(expectedIntegrityAttributes)
+    expect(inlineScriptHashes).toBe(expectedInlineScriptHashes + 1) // Inlined script in head
+    expect(externalScriptHashes).toBe(expectedExternalScriptHashes + 1) // + 1 vue modulepreload
+    expect(inlineStyleHashes).toBe(expectedInlineStyleHashes)
+    expect(externalStyleHashes).toBe(expectedExternalStyleHashes)
+  })
+
   it('sets style-src for inline styles', async () => {
     const res = await fetch('/inline-style')
+
+    const body = await res.text()
+    const { metaTag, csp, elementsWithIntegrity, inlineScriptHashes, externalScriptHashes, inlineStyleHashes, externalStyleHashes } = extractDataFromBody(body)
+
+    expect(res).toBeDefined()
+    expect(res).toBeTruthy()
+    expect(body).toBeDefined()
+    expect(metaTag).toBeDefined()
+    expect(csp).toBeDefined()
+    expect(elementsWithIntegrity).toBe(expectedIntegrityAttributes)
+    expect(inlineScriptHashes).toBe(expectedInlineScriptHashes)
+    expect(externalScriptHashes).toBe(expectedExternalScriptHashes + 1) // + 1 vue modulepreload
+    expect(inlineStyleHashes).toBe(expectedInlineStyleHashes + 1) // Inlined style
+    expect(externalStyleHashes).toBe(expectedExternalStyleHashes)
+  })
+
+  it('sets style-src for inline styles with line break', async () => {
+    const res = await fetch('/inline-style-with-linebreak')
 
     const body = await res.text()
     const { metaTag, csp, elementsWithIntegrity, inlineScriptHashes, externalScriptHashes, inlineStyleHashes, externalStyleHashes } = extractDataFromBody(body)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR updates the regular expressions in the `30-cspSsgHashes.ts` file. The previous regular expression was not correctly capturing the content of inline script and style tags in all scenarios. 

The old regular expression for inline scripts:
```typescript
const INLINE_SCRIPT_RE = /<script(?![^>]*?\bsrc="[\w:.\-\\/]+")[^>]*>(.*?)<\/script>/gi
```

The updated regular expression:
```typescript
const INLINE_SCRIPT_RE = /<script(?![^>]*?\bsrc="[\w:.\-\\/]+")[^>]*>([\s\S]*?)<\/script>/gi;
```

The change from `(.*?)` to `([\s\S]*?)` ensures that the regular expression matches any character, including newlines, between the `<script>` and `</script>` tags. This change improves the accuracy of inline script content capture, ensuring that our CSP security hashes are correctly generated for all inline scripts.

Same changes are made in inline styles.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
