### PR TITLE
fix(docs): csp denial of pinceau styles runtime hydration

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -16,6 +16,7 @@ export default defineNuxtConfig({
     strict: true,
     headers: {
       contentSecurityPolicy: {
+        'style-src': ["'self'", "'unsafe-inline'"],
         'img-src': ["'self'", "data:", 'https:'], // Allow https: external images
         'connect-src': process.env.NODE_ENV === 'development' ? ["'self'", 'https:', 'ws:'] : ["'self'", 'https:'], // Allow websocket in dev mode
         'frame-src': ['https://www.youtube-nocookie.com', 'https://stackblitz.com'], // Allow youtube and stackblitz iframes
@@ -25,6 +26,9 @@ export default defineNuxtConfig({
         "fullscreen": ['self', '"https://www.youtube-nocookie.com"'], // Allow fullscreen for youtube
       },
       crossOriginEmbedderPolicy: 'unsafe-none', // Allow youtube and stackblitz iframes
+    },
+    ssg: {
+      hashStyles: false
     }
   }
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The documentation page is broken with the new `strict` mode.

In rc-9, the `strict` mode denies unsafe-inline styles by default, which are required by pinceau.
This patch updates the documentation setup to allow pinceau runtime hydration.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
