### PR TITLE
 fix: augment @nuxt/schema rather than nuxt/schema

### DIFF
--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -38,7 +38,7 @@ export type NuxtSecurityRouteRules = Partial<
   & { requestSizeLimiter: RequestSizeLimiter | false }
 >
 
-declare module 'nuxt/schema' {
+declare module '@nuxt/schema' {
   interface NuxtOptions {
     security: ModuleOptions
   }
@@ -46,12 +46,6 @@ declare module 'nuxt/schema' {
     security: ModuleOptions,
     private: { basicAuth: BasicAuth | false, [key: string]: any }
   }
-  interface NuxtHooks {
-    'nuxt-security:prerenderedHeaders': (prerenderedHeaders: Record<string, Record<string, string>>) => HookResult
-  }
-}
-
-declare module '@nuxt/schema' {
   interface NuxtHooks {
     'nuxt-security:prerenderedHeaders': (prerenderedHeaders: Record<string, Record<string, string>>) => HookResult
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Context: nuxt/nuxt#28332

`nuxt/schema` is a re-export of `@nuxt/schema` for users to use. Modules should not augment it, or it may end up overwriting the inferred types from `@nuxt/schema`.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
