### PR TITLE
fix: devtools being blocked in strict mode

### DIFF
--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -96,7 +96,7 @@ export const defaultSecurityConfig = (serverlUrl: string, strict: boolean) => {
   }
 
   if (strict) {
-    defaultConfig.headers.crossOriginEmbedderPolicy = 'require-corp'
+    defaultConfig.headers.crossOriginEmbedderPolicy = process.env.NODE_ENV === 'development' ? 'unsafe-none' : 'require-corp'
     defaultConfig.headers.contentSecurityPolicy = {
       'base-uri': ["'none'"],
       'default-src' : ["'none'"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Fix devtools being blocked when strict mode is enabled

88dbb4c4f7d10e05a01336d6bf409e1434aaabd5 the existing documentation has been removed, so it should work the same in strict mode as in none-strict mode 

ref: #487

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
