### PR TITLE
feat(core): Vite native method to remove loggers

### DIFF
--- a/docs/content/1.documentation/1.getting-started/2.configuration.md
+++ b/docs/content/1.documentation/1.getting-started/2.configuration.md
@@ -26,7 +26,7 @@ interface ModuleOptions {
   enabled: boolean;
   csrf: CsrfOptions | false;
   nonce: boolean;
-  removeLoggers: RemoveOptions | false;
+  removeLoggers: boolean | RemoveOptions; // RemoveOptions is being deprecated, please use `true` instead
   ssg: Ssg | false;
   sri: boolean;
 }
@@ -112,12 +112,7 @@ security: {
   enabled: true,
   csrf: false,
   nonce: true,
-  removeLoggers: {
-    external: [],
-    consoleType: ['log', 'debug'],
-    include: [/\.[jt]sx?$/, /\.vue\??/],
-    exclude: [/node_modules/, /\.git/]
-  },
+  removeLoggers: true,
   ssg: {
     meta: true,
     hashScripts: true,

--- a/docs/content/1.documentation/4.utils/2.remove-console-loggers.md
+++ b/docs/content/1.documentation/4.utils/2.remove-console-loggers.md
@@ -12,13 +12,58 @@ By default, your application will allow log all activity in the browser when you
 ℹ Read more about it [here](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html#data-to-exclude).
 ::
 
-Fortunately, `nuxt-security` module removes both `log` and `debug` console outputs by default so your application is not leaking this information.
+Fortunately, the Nuxt Security module removes all `console` outputs by default so your application is not leaking this information.
+Nuxt Security also removes all `debugger` statements from your code.
 
-This functionality is delivered by the amazing Vite Plugin by [Talljack](https://github.com/Talljack) that you can check out [here](https://github.com/Talljack/unplugin-remove).
+## Options
+
+This feature is enabled globally default.
+
+You can disable the feature by setting `removeLoggers: false`:
+
+```js{}[nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['nuxt-security'],
+
+  security: {
+    removeLoggers: false
+  }
+})
+```
+
+## Alternative method - deprecated
+
+By default when you set `removeLoggers: true`, Nuxt Security uses the native Vite features to remove statements.
+
+In addition, Nuxt Security also supports an alternative method for removing console outputs, via the amazing `unplugin-remove` Vite Plugin by [Talljack](https://github.com/Talljack) that you can check out [here](https://github.com/Talljack/unplugin-remove).
+
+::alert{type="warning"}
+ℹ The `unplugin-remove` method is being deprecated and will be removed in a future release.
+Please note that `unplugin-remove` will not remove `debugger` statements from your code.
+::
+
+If you want to use the `unplugin-remove` plugin method, pass an object to the `removeLoggers` configuration instead of passing `true`.
+
+```js{}[nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['nuxt-security'],
+
+  security: {
+    removeLoggers: {
+      external: [],
+      consoleType: ['log', 'debug'],
+      include: [/\.[jt]sx?$/, /\.vue\??/],
+      exclude: [/node_modules/, /\.git/]
+    }
+  }
+})
+```
+
+The `removeLoggers` object can be configured with following values.
 
 ```ts
-import type { FilterPattern } from '@rollup/pluginutils'
-export interface Options {
+// https://github.com/Talljack/unplugin-remove/blob/main/src/types.ts
+type RemoveOptions {
   /**
    * don't remove console.log and debugger these module
    *
@@ -46,33 +91,4 @@ export interface Options {
    */
   exclude?: FilterPattern
 }
-```
-
-If you would like to add some custom functionality to it, you can do so by doing the following:
-
-```js{}[nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['nuxt-security'],
-
-  security: {
-    removeLoggers: {
-      external: [],
-      consoleType: ['log', 'debug'],
-      include: [/\.[jt]sx?$/, /\.vue\??/],
-      exclude: [/node_modules/, /\.git/]
-    }
-  }
-})
-```
-
-However, if you prefer not to have this, you can always disable this functionality from the module configuration (which is not recommended but possible) like the following:
-
-```js{}[nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['nuxt-security'],
-
-  security: {
-    removeLoggers: false
-  }
-})
 ```

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -78,13 +78,7 @@ export const defaultSecurityConfig = (serverlUrl: string, strict: boolean) => {
     enabled: true,
     csrf: false,
     nonce: true,
-    // https://github.com/Talljack/unplugin-remove/blob/main/src/types.ts
-    removeLoggers: {
-      external: [],
-      consoleType: ['log', 'debug'],
-      include: [/\.[jt]sx?$/, /\.vue\??/],
-      exclude: [/node_modules/, /\.git/]
-    },
+    removeLoggers: true,
     ssg: {
       meta: true,
       hashScripts: true,

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -28,11 +28,11 @@ export interface ModuleOptions {
   sri: boolean
   basicAuth: BasicAuth | false;
   csrf: CsrfOptions | boolean;
-  removeLoggers: RemoveOptions | false;
+  removeLoggers: RemoveOptions | boolean;
 }
 
 export type NuxtSecurityRouteRules = Partial<
-  Omit<ModuleOptions, 'strict' | 'csrf' | 'basicAuth' | 'rateLimiter' | 'ssg' | 'requestSizeLimiter' > 
+  Omit<ModuleOptions, 'strict' | 'csrf' | 'basicAuth' | 'rateLimiter' | 'ssg' | 'requestSizeLimiter' | 'removeLoggers' > 
   & { rateLimiter: Omit<RateLimiter, 'driver'> | false }
   & { ssg: Omit<Ssg, 'exportToPresets'> | false }
   & { requestSizeLimiter: RequestSizeLimiter | false }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2602,15 +2602,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599:
-  version "1.0.30001605"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz"
-  integrity sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==
-
-caniuse-lite@^1.0.30001646:
-  version "1.0.30001651"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz#52de59529e8b02b1aedcaaf5c05d9e23c0c28138"
-  integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599, caniuse-lite@^1.0.30001646:
+  version "1.0.30001668"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz"
+  integrity sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==
 
 chai@^4.3.10:
   version "4.4.1"
@@ -6483,16 +6478,7 @@ streamx@^2.15.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6524,14 +6510,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7380,16 +7359,7 @@ wide-align@^1.1.2:
   dependencies:
     string-width "^1.0.2 || 2 || 3 || 4"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

Fixes #533

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

This PR introduces an alternative method for removing `console.log` statements.

The new method is based on Vite's native functionalities, whereas the currently existing method is based on the external `unplugin-remove` package.

The `removeLoggers` option can now accept a new value, which is `true`. The new method is enabled when  `removeLoggers` is set to `true`, while the `unplugin-remove` package is still used when an object is used. This approach maintains compatibility with existing setups.

By default, `removeLoggers` is now set to `true`. This approach soft-deprecates the `unplugin-remove` method in all default setups.

We intend to fully deprecate the old approach in a future release.


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
