### PR TITLE
fix(core): do not create empty header entries in routeRules

### DIFF
--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -173,11 +173,16 @@ function appliesToAllResources(optionKey: OptionKey) {
  * Extract the subset of security headers that apply to all resources
  */
 export function getHeadersApplicableToAllResources(headers: SecurityHeaders) {
-  return <Record<HeaderName, string>>Object.fromEntries(
+  const applicableHeaders = <Record<HeaderName, string>>Object.fromEntries(
     Object.entries(headers)
     .filter(([key]) => appliesToAllResources(key as OptionKey))
     .map(([key, value]) => ([getNameFromKey(key as OptionKey), headerStringFromObject(key as OptionKey, value)]))
   )
+  if (Object.keys(applicableHeaders).length === 0) {
+    return undefined
+  } else {
+    return applicableHeaders
+  }
 }
 
 

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -178,11 +178,7 @@ export function getHeadersApplicableToAllResources(headers: SecurityHeaders) {
     .filter(([key]) => appliesToAllResources(key as OptionKey))
     .map(([key, value]) => ([getNameFromKey(key as OptionKey), headerStringFromObject(key as OptionKey, value)]))
   )
-  if (Object.keys(applicableHeaders).length === 0) {
-    return undefined
-  } else {
-    return applicableHeaders
-  }
+  return Object.keys(applicableHeaders).length === 0 ? undefined : applicableHeaders
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->
Fixes #538

The `getHeadersApplicableToAllRessources` was previously returning an empty object `{}` when no eligible entry was found, which resulted in an empty `headers: {}` entry in the routeRules registry.

This could trigger a deployment failure in some Nitro presets (e.g. Vercel).

This PR ensures that no `headers` entry is created in the corresponding routeRule in that case, fixing the bug described in #538.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
