### PR TITLE
fix: #564 resolves issue with element.replace on non-string elements

### DIFF
--- a/src/runtime/nitro/plugins/40-cspSsrNonce.ts
+++ b/src/runtime/nitro/plugins/40-cspSsrNonce.ts
@@ -52,6 +52,10 @@ export default defineNitroPlugin((nitroApp) => {
     const sections = ['body', 'bodyAppend', 'bodyPrepend', 'head'] as Section[]
     for (const section of sections) {
       html[section] = html[section].map((element) => {
+        // Skip non-string elements
+        if (typeof element !== 'string') {
+          return element;
+        }
         // Add nonce to all link tags
         element = element.replace(LINK_RE, (match, rest) => {
           return `<link nonce="${nonce}"` + rest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
This PR fixes an issue in the `cspSsrNonce.ts` file where `element.replace` was called on non-string elements in the `html[section]` array during nonce injection. This caused a `TypeError: element.replace is not a function` in SSR mode when third-party libraries, such as PrimeVue, injected non-string elements.

The change introduces a type check to skip non-string elements, ensuring the rendering process doesn’t break and nonce attributes are properly applied to valid elements.

**Why is this change required?**
This resolves a crash in applications using Nuxt Security with SSR and libraries like PrimeVue.

Resolves: #564 


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
  - Tests are not applicable in this case since the change addresses runtime behavior with specific third-party library interactions. I did, however, verify existing tests.
