### PR TITLE
#624 - Update incorrect permissions policy docs

### DIFF
--- a/docs/content/2.headers/2.permissions-policy.md
+++ b/docs/content/2.headers/2.permissions-policy.md
@@ -142,7 +142,7 @@ export default defineNuxtConfig({
       security: {
         headers: {
           permissionsPolicy: {
-            'geolocation': ['self', 'https://*.example.com']  // Self AND *.example.com allowed for routes beginning with /some-prefix/some-route/
+            'geolocation': ['self', '"https://*.example.com"']  // Self AND *.example.com allowed for routes beginning with /some-prefix/some-route/
           }
         }
       }


### PR DESCRIPTION
This resolves #624. The URLs in the permissions policy must be enquoted, so they are correctly parsed into the permissions-policy header.

<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
