### PR TITLE
fix(headers): add ssg hashes for `script-src-elem` and `style-src-elem`

### DIFF
--- a/src/runtime/nitro/plugins/50-updateCsp.ts
+++ b/src/runtime/nitro/plugins/50-updateCsp.ts
@@ -54,10 +54,10 @@ function updateCspVariables(csp: ContentSecurityPolicyValue, nonce?: string, scr
       })
       .filter(source => source)
     
-    if (directive === 'script-src' && scriptHashes) {
+    if (['script-src', 'script-src-elem'].includes(directive) && scriptHashes) {
       modifiedSources.push(...scriptHashes)
     }
-    if (directive === 'style-src' && styleHashes) {
+    if (['style-src', 'style-src-elem'].includes(directive) && styleHashes) {
       modifiedSources.push(...styleHashes)
     }
 

--- a/test/fixtures/ssgHashes/nuxt.config.ts
+++ b/test/fixtures/ssgHashes/nuxt.config.ts
@@ -6,6 +6,19 @@ export default defineNuxtConfig({
     '/': {
       prerender: true
     },
+    '/inline-elem': {
+      prerender: true,
+      security: {
+        headers: {
+          contentSecurityPolicy: {
+            "script-src": false,
+            "style-src": false,
+            "script-src-elem": [],
+            "style-src-elem": []
+          }
+        }
+      }
+    },
     '/inline-script': {
       prerender: true
     },

--- a/test/fixtures/ssgHashes/pages/inline-elem.vue
+++ b/test/fixtures/ssgHashes/pages/inline-elem.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    Default page
+  </div>
+</template>
+<script setup>
+useHead({
+  script: [
+    { textContent: 'window.myImportantVar = 1', type: 'text/javascript' }
+  ],
+  style: [
+    { textContent: 'div { color: blue }', type: 'text/css' }
+  ]
+})
+</script>

--- a/test/ssgHashes.test.ts
+++ b/test/ssgHashes.test.ts
@@ -66,6 +66,16 @@ describe('[nuxt-security] SSG support of CSP', async () => {
     expect(strippedHeaderCsp).toBe(metaCsp)
   })
 
+  it('sets script- and style-src-elem for inline scripts and styles', async () => {
+    const res = await fetch('/inline-elem')
+
+    const body = await res.text()
+    const { csp } = extractDataFromBody(body)
+
+    expect(csp).toMatch(/script-src-elem[^;]+'sha256-/)
+    expect(csp).toMatch(/style-src-elem[^;]+'sha256-/)
+  })
+
   it('sets script-src for inline scripts', async () => {
     const res = await fetch('/inline-script')
 
@@ -88,7 +98,7 @@ describe('[nuxt-security] SSG support of CSP', async () => {
     const res = await fetch('/inline-script-with-linebreak')
     const body = await res.text()
     const { metaTag, csp, elementsWithIntegrity, inlineScriptHashes, externalScriptHashes, inlineStyleHashes, externalStyleHashes } = extractDataFromBody(body)
-    
+
     expect(res).toBeDefined()
     expect(res).toBeTruthy()
     expect(body).toBeDefined()


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
I'm using `script-src-elem` instead of `script-src`, but SSG hashes are only added to the latter and then dropped because `script-src-elem` takes precedence. Thus, my CSP ends up with no script hashes at all.
This PR allows `script-src-elem` to accept hashes aswell and adds a test for that.

## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
