### PR TITLE
fix(docs): update link to useScript

### DIFF
--- a/docs/content/2.headers/1.csp.md
+++ b/docs/content/2.headers/1.csp.md
@@ -365,7 +365,7 @@ If you change these default values, please refer to our [Advanced Section on CSP
 useScript('https://example.com/script.js')
 ```
   
-Please see [useScript](https://unhead.unjs.io/usage/composables/use-script) for available options and usage.
+Please see [useScript](https://unhead.unjs.io/docs/typescript/head/api/composables/use-script) for available options and usage.
 
 
 - Before Nuxt 3.11, you can also include your external scripts via `useHead`


### PR DESCRIPTION
I recently ran into a dead link in Nuxt Security docs, so I am providing a fix. There was a change in structure and Unhead doesn't handle redirections.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
- Go to https://nuxt-security.vercel.app/headers/csp#including-external-scripts
- Click `useScript` link
- https://unhead.unjs.io/docs/typescript/head/api/composables/use-script leads to

<img width="1253" height="296" alt="image" src="https://github.com/user-attachments/assets/06ca0d87-eeb6-47c3-97cc-9b3395bb08d2" />

I added new link that respects new page structure:
- https://unhead.unjs.io/docs/typescript/head/api/composables/use-script

<img width="691" height="322" alt="image" src="https://github.com/user-attachments/assets/d085a880-52b8-40af-b5c2-093e853d302f" />


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)

I don't think there are tests for link validity...
