### PR TITLE
fix: mask escaped strings properly

### DIFF
--- a/src/runtime/nitro/plugins/40-cspSsrNonce.ts
+++ b/src/runtime/nitro/plugins/40-cspSsrNonce.ts
@@ -6,7 +6,7 @@ const LINK_RE = /<link\b([^>]*?>)/gi
 const NONCE_RE = /nonce="[^"]+"/i
 const SCRIPT_RE = /<script\b([^>]*?>)/gi
 const STYLE_RE = /<style\b([^>]*?>)/gi
-const QUOTE_MASK_RE = /"([^"]*)"/g
+const QUOTE_MASK_RE = /"((?:[^"\\]|\\.)*)"/g
 const QUOTE_RESTORE_RE = /__QUOTE_PLACEHOLDER_(\d+)__/g
 
 function injectNonceToTags(element: string, nonce: string) {


### PR DESCRIPTION
When a string in the content contains a single escaped double quote, the masking of the string fails in the CSP Nonce handler. This results in an issue with the following parts of the string, causing issues like #667 

## Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

I updated the regex so it matches only true double quotes after the opening quotes. Escaped quotes `\"` are now included in the placeholder content.

Resolves #667

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
