### PR TITLE
feat(csp): add support for Content-Security-Policy-Report-Only header

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -28,6 +28,7 @@ interface ModuleOptions {
   removeLoggers: boolean | RemoveOptions; // RemoveOptions is being deprecated, please use `true` instead
   ssg: Ssg | false;
   sri: boolean;
+  contentSecurityPolicyReportOnly: boolean;
 }
 ```
 
@@ -119,7 +120,8 @@ security: {
     nitroHeaders: true,
     exportToPresets: true,
   },
-  sri: true
+  sri: true,
+  contentSecurityPolicyReportOnly: false;
 }
 ```
 

--- a/docs/content/2.headers/1.csp.md
+++ b/docs/content/2.headers/1.csp.md
@@ -82,7 +82,6 @@ contentSecurityPolicy: {
   'require-trusted-types-for'?: string | false;
   'trusted-types'?: string[] | string | false;
   'upgrade-insecure-requests'?: boolean;
-  'report-only'?: boolean;
 } | false
 ```
 
@@ -137,9 +136,9 @@ You can enable CSP in report-only mode to monitor violations without blocking an
 ```ts
 export default defineNuxtConfig({
   security: {
+    contentSecurityPolicyReportOnly: true,
     headers: {
       contentSecurityPolicy: {
-        'report-only': true,
         'script-src': ["'self'", "'strict-dynamic'"],
         'report-uri': ['/api/csp-report']
       }
@@ -148,11 +147,7 @@ export default defineNuxtConfig({
 })
 ```
 
-When `'report-only': true` is set, the `Content-Security-Policy-Report-Only` header will be used instead of `Content-Security-Policy`.
-
-::callout{icon="i-heroicons-light-bulb"}
-The `'report-only'` option controls the header name and will not appear in the actual header value.
-::
+When `contentSecurityPolicyReportOnly: true` is set, the `Content-Security-Policy-Report-Only` header will be used instead of `Content-Security-Policy`.
 
 
 ## Strict CSP

--- a/docs/content/2.headers/1.csp.md
+++ b/docs/content/2.headers/1.csp.md
@@ -82,6 +82,7 @@ contentSecurityPolicy: {
   'require-trusted-types-for'?: string | false;
   'trusted-types'?: string[] | string | false;
   'upgrade-insecure-requests'?: boolean;
+  'report-only'?: boolean;
 } | false
 ```
 
@@ -126,6 +127,31 @@ type CSPSandboxValue =
 | 'allow-top-navigation-by-user-activation'
 | 'allow-top-navigation-to-custom-protocols';
 ```
+::
+
+
+## Report-Only Mode
+
+You can enable CSP in report-only mode to monitor violations without blocking any content. This is useful for testing CSP policies before enforcing them.
+
+```ts
+export default defineNuxtConfig({
+  security: {
+    headers: {
+      contentSecurityPolicy: {
+        'report-only': true,
+        'script-src': ["'self'", "'strict-dynamic'"],
+        'report-uri': ['/api/csp-report']
+      }
+    }
+  }
+})
+```
+
+When `'report-only': true` is set, the `Content-Security-Policy-Report-Only` header will be used instead of `Content-Security-Policy`.
+
+::callout{icon="i-heroicons-light-bulb"}
+The `'report-only'` option controls the header name and will not appear in the actual header value.
 ::
 
 

--- a/docs/content/5.advanced/2.faq.md
+++ b/docs/content/5.advanced/2.faq.md
@@ -202,9 +202,9 @@ You can enable report-only mode directly in your CSP configuration:
 export default defineNuxtConfig({
   // Global configuration
   security: {
+    contentSecurityPolicyReportOnly: true,
     headers: {
       contentSecurityPolicy: {
-        'report-only': true,
         'script-src': ["'self'", "'strict-dynamic'"],
         'report-uri': ['/api/csp-report']
       }
@@ -215,18 +215,14 @@ export default defineNuxtConfig({
   routeRules: {
     '/test-csp/**': {
       security: {
-        headers: {
-          contentSecurityPolicy: {
-            'report-only': true
-          }
-        }
+        contentSecurityPolicyReportOnly: true;
       }
     }
   }
 })
 ```
 
-When `'report-only': true` is set, the module will use the `Content-Security-Policy-Report-Only` header instead of `Content-Security-Policy`. This allows you to test CSP rules without blocking any content.
+When `contentSecurityPolicyReportOnly: true` is set, the module will use the `Content-Security-Policy-Report-Only` header instead of `Content-Security-Policy`. This allows you to test CSP rules without blocking any content.
 
 ## Allowing images and scripts from external domains
 

--- a/docs/content/5.advanced/2.faq.md
+++ b/docs/content/5.advanced/2.faq.md
@@ -194,23 +194,39 @@ To test it, run your application and then in another test application running on
 
 The HTTP Content-Security-Policy-Report-Only response header allows web developers to experiment with policies by monitoring (but not enforcing) their effects. These violation reports consist of JSON documents sent via an HTTP POST request to the specified URI.
 
-You can add it to your project like this:
+You can enable report-only mode directly in your CSP configuration:
 
 ```ts
 // nuxt.config.ts
 
-routeRules: {
-  '/**': {
+export default defineNuxtConfig({
+  // Global configuration
+  security: {
     headers: {
-      'Content-Security-Policy-Report-Only': '<YOUR_DESIRED_VALUE>'
-    },
+      contentSecurityPolicy: {
+        'report-only': true,
+        'script-src': ["'self'", "'strict-dynamic'"],
+        'report-uri': ['/api/csp-report']
+      }
+    }
   },
-},
+
+  // Or per route
+  routeRules: {
+    '/test-csp/**': {
+      security: {
+        headers: {
+          contentSecurityPolicy: {
+            'report-only': true
+          }
+        }
+      }
+    }
+  }
+})
 ```
 
-::callout{icon="i-heroicons-light-bulb"}
- Read more about it [here](https://github.com/Baroshem/nuxt-security/issues/193#issuecomment-1669009189).
-::
+When `'report-only': true` is set, the module will use the `Content-Security-Policy-Report-Only` header instead of `Content-Security-Policy`. This allows you to test CSP rules without blocking any content.
 
 ## Allowing images and scripts from external domains
 

--- a/playground/app/pages/cspReportOnly.vue
+++ b/playground/app/pages/cspReportOnly.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Same CSP configuration but using Content-Security-Policy-Report-Only header
+  </div>
+</template>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -55,6 +55,15 @@ export default defineNuxtConfig({
         },
       },
     },
+    '/cspReportOnly': {
+      security: {
+        headers: {
+          contentSecurityPolicy: {
+            'report-only': true,
+          }
+        }
+      }
+    }
   },
 
   // Global configuration

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -57,11 +57,7 @@ export default defineNuxtConfig({
     },
     '/cspReportOnly': {
       security: {
-        headers: {
-          contentSecurityPolicy: {
-            'report-only': true,
-          }
-        }
+        contentSecurityPolicyReportOnly: true
       }
     }
   },

--- a/src/defaultConfig.ts
+++ b/src/defaultConfig.ts
@@ -88,7 +88,8 @@ export const defaultSecurityConfig = (serverlUrl: string, strict: boolean) => {
       nitroHeaders: true,
       exportToPresets: true,
     },
-    sri: true
+    sri: true,
+    contentSecurityPolicyReportOnly: false
   }
 
   if (strict) {

--- a/src/runtime/nitro/plugins/70-securityHeaders.ts
+++ b/src/runtime/nitro/plugins/70-securityHeaders.ts
@@ -14,7 +14,12 @@ export default defineNitroPlugin((nitroApp) => {
       const headers = rules.headers
 
       Object.entries(headers).forEach(([header, value]) => {
-        const headerName = getNameFromKey(header as OptionKey)
+        const headerName = getNameFromKey(
+          header as OptionKey,
+          header === 'contentSecurityPolicy' && value && typeof value === 'object'
+            ? { reportOnly: (value as Record<string, unknown>)['report-only'] === true }
+            : undefined
+        )
         if (value === false) {
           const { headers: standardHeaders } = getRouteRules(event)
           const standardHeaderValue = standardHeaders?.[headerName]

--- a/src/runtime/nitro/plugins/70-securityHeaders.ts
+++ b/src/runtime/nitro/plugins/70-securityHeaders.ts
@@ -2,7 +2,7 @@ import { defineNitroPlugin, getRouteRules } from 'nitropack/runtime'
 import { setResponseHeader, removeResponseHeader, getResponseHeader } from 'h3'
 import { resolveSecurityRules } from '../context'
 import { getNameFromKey, headerStringFromObject } from '../../../utils/headers'
-import type { OptionKey } from '../../../types/headers'
+import type { HeaderName, OptionKey } from '../../../types/headers'
 
 /**
  * This plugin sets the security headers for the response.
@@ -14,12 +14,10 @@ export default defineNitroPlugin((nitroApp) => {
       const headers = rules.headers
 
       Object.entries(headers).forEach(([header, value]) => {
-        const headerName = getNameFromKey(
-          header as OptionKey,
-          header === 'contentSecurityPolicy' && value && typeof value === 'object'
-            ? { reportOnly: (value as Record<string, unknown>)['report-only'] === true }
-            : undefined
-        )
+        const headerName: HeaderName = header === 'contentSecurityPolicy' && rules.contentSecurityPolicyReportOnly
+          ? 'Content-Security-Policy-Report-Only'
+          : getNameFromKey(header as OptionKey)
+
         if (value === false) {
           const { headers: standardHeaders } = getRouteRules(event)
           const standardHeaderValue = standardHeaders?.[headerName]

--- a/src/types/headers.ts
+++ b/src/types/headers.ts
@@ -89,10 +89,6 @@ export type ContentSecurityPolicyValue = {
   'require-trusted-types-for'?: string | false;
   'trusted-types'?: string[] | string | false;
   'upgrade-insecure-requests'?: boolean;
-  /**
-   * When set to true, the Content-Security-Policy-Report-Only header will be used instead of Content-Security-Policy.
-   */
-  'report-only'?: boolean;
 };
 
 export type StrictTransportSecurityValue = {

--- a/src/types/headers.ts
+++ b/src/types/headers.ts
@@ -89,6 +89,10 @@ export type ContentSecurityPolicyValue = {
   'require-trusted-types-for'?: string | false;
   'trusted-types'?: string[] | string | false;
   'upgrade-insecure-requests'?: boolean;
+  /**
+   * When set to true, the Content-Security-Policy-Report-Only header will be used instead of Content-Security-Policy.
+   */
+  'report-only'?: boolean;
 };
 
 export type StrictTransportSecurityValue = {
@@ -165,7 +169,7 @@ export type PermissionsPolicyValue = {
   /**
    * 🧪 Experimental. Expect browser behavior to change in the future.
    */
-  
+
   'idle-detection'?: string[] | string | false;
   /**
    * 🧪 Mozilla-undocumented. Expect browser behavior to change in the future.
@@ -222,7 +226,7 @@ export type PermissionsPolicyValue = {
   /**
    * 🧪 Experimental. Expect browser behavior to change in the future.
    */
-  
+
   'usb'?: string[] | string | false;
   /**
    * 🧪 Mozilla-undocumented. Expect browser behavior to change in the future.
@@ -246,13 +250,13 @@ export type PermissionsPolicyValue = {
   'xr-spatial-tracking'?: string[] | string | false;
 }
 
-export type OptionKey = 
-  'contentSecurityPolicy' | 
-  'crossOriginEmbedderPolicy' | 
+export type OptionKey =
+  'contentSecurityPolicy' |
+  'crossOriginEmbedderPolicy' |
   'crossOriginOpenerPolicy' |
   'crossOriginResourcePolicy' |
-  'originAgentCluster' | 
-  'referrerPolicy' | 
+  'originAgentCluster' |
+  'referrerPolicy' |
   'strictTransportSecurity' |
   'xContentTypeOptions' |
   'xDNSPrefetchControl' |
@@ -262,8 +266,9 @@ export type OptionKey =
   'xXSSProtection' |
   'permissionsPolicy'
 
-export type HeaderName = 
+export type HeaderName =
   'Content-Security-Policy' |
+  'Content-Security-Policy-Report-Only' |
   'Cross-Origin-Embedder-Policy' |
   'Cross-Origin-Opener-Policy' |
   'Cross-Origin-Resource-Policy' |

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -29,6 +29,7 @@ export interface ModuleOptions {
   basicAuth: BasicAuth | false;
   csrf: CsrfOptions | boolean;
   removeLoggers: RemoveOptions | boolean;
+  contentSecurityPolicyReportOnly: boolean;
 }
 
 export type NuxtSecurityRouteRules = Partial<

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -30,7 +30,10 @@ const NAMES_TO_KEYS = Object.fromEntries(Object.entries(KEYS_TO_NAMES).map(([key
  *
  * Converts a valid OptionKey into its corresponding standard header name
  */
-export function getNameFromKey(key: OptionKey) {
+export function getNameFromKey(key: OptionKey, options?: { reportOnly?: boolean }) {
+  if (key === 'contentSecurityPolicy' && options?.reportOnly) {
+    return 'Content-Security-Policy-Report-Only' as HeaderName
+  }
   return KEYS_TO_NAMES[key]
 }
 
@@ -56,7 +59,7 @@ export function headerStringFromObject(optionKey: OptionKey, optionValue: Exclud
   if (optionKey === 'contentSecurityPolicy') {
     const policies = optionValue as ContentSecurityPolicyValue
     return Object.entries(policies)
-      .filter(([, value]) => value !== false)
+      .filter(([directive, value]) => value !== false && directive !== 'report-only')
       .map(([directive, sources]) => {
         if (directive === 'upgrade-insecure-requests') {
           return 'upgrade-insecure-requests;'

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -30,10 +30,7 @@ const NAMES_TO_KEYS = Object.fromEntries(Object.entries(KEYS_TO_NAMES).map(([key
  *
  * Converts a valid OptionKey into its corresponding standard header name
  */
-export function getNameFromKey(key: OptionKey, options?: { reportOnly?: boolean }) {
-  if (key === 'contentSecurityPolicy' && options?.reportOnly) {
-    return 'Content-Security-Policy-Report-Only' as HeaderName
-  }
+export function getNameFromKey(key: OptionKey) {
   return KEYS_TO_NAMES[key]
 }
 
@@ -59,7 +56,7 @@ export function headerStringFromObject(optionKey: OptionKey, optionValue: Exclud
   if (optionKey === 'contentSecurityPolicy') {
     const policies = optionValue as ContentSecurityPolicyValue
     return Object.entries(policies)
-      .filter(([directive, value]) => value !== false && directive !== 'report-only')
+      .filter(([, value]) => value !== false)
       .map(([directive, sources]) => {
         if (directive === 'upgrade-insecure-requests') {
           return 'upgrade-insecure-requests;'

--- a/test/fixtures/perRoute/nuxt.config.ts
+++ b/test/fixtures/perRoute/nuxt.config.ts
@@ -284,6 +284,25 @@ export default defineNuxtConfig({
           contentSecurityPolicy: false
         }
       }
+    },
+    '/csp-report-only/**': {
+      security: {
+        headers: {
+          contentSecurityPolicy: {
+            'report-only': true,
+            'script-src': ["'self'", "'strict-dynamic'", "example.com"]
+          }
+        }
+      }
+    },
+    '/csp-report-only/deep/disabled': {
+      security: {
+        headers: {
+          contentSecurityPolicy: {
+            'report-only': false
+          }
+        }
+      }
     }
   },
   security: {

--- a/test/fixtures/perRoute/nuxt.config.ts
+++ b/test/fixtures/perRoute/nuxt.config.ts
@@ -287,9 +287,9 @@ export default defineNuxtConfig({
     },
     '/csp-report-only/**': {
       security: {
+        contentSecurityPolicyReportOnly: true,
         headers: {
           contentSecurityPolicy: {
-            'report-only': true,
             'script-src': ["'self'", "'strict-dynamic'", "example.com"]
           }
         }
@@ -297,11 +297,7 @@ export default defineNuxtConfig({
     },
     '/csp-report-only/deep/disabled': {
       security: {
-        headers: {
-          contentSecurityPolicy: {
-            'report-only': false
-          }
-        }
+        contentSecurityPolicyReportOnly: false
       }
     }
   },

--- a/test/fixtures/perRoute/pages/csp-report-only/deep/disabled.vue
+++ b/test/fixtures/perRoute/pages/csp-report-only/deep/disabled.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>CSP Report-Only Disabled Test Page</div>
+</template>

--- a/test/fixtures/perRoute/pages/csp-report-only/deep/page.vue
+++ b/test/fixtures/perRoute/pages/csp-report-only/deep/page.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>CSP Report-Only Deep Test Page</div>
+</template>

--- a/test/fixtures/perRoute/pages/csp-report-only/index.vue
+++ b/test/fixtures/perRoute/pages/csp-report-only/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>CSP Report-Only Test Page</div>
+</template>

--- a/test/perRoute.test.ts
+++ b/test/perRoute.test.ts
@@ -976,4 +976,44 @@ describe('[nuxt-security] Per-route Configuration', async () => {
     expect(rp).toBeDefined()
     expect(rp).toBeNull()
   })
+
+  it('sets Content-Security-Policy-Report-Only header when report-only is true', async () => {
+    const res = await fetch('/csp-report-only')
+    expect(res.status).toBe(200)
+
+    const { headers } = res
+    const csp = headers.get('content-security-policy')
+    const cspReportOnly = headers.get('content-security-policy-report-only')
+
+    expect(csp).toBeNull()
+    expect(cspReportOnly).toBeDefined()
+    expect(cspReportOnly).toContain("script-src 'self' 'strict-dynamic' example.com;")
+    expect(cspReportOnly).not.toContain('report-only')
+  })
+
+  it('inherits report-only on deep routes', async () => {
+    const res = await fetch('/csp-report-only/deep/page')
+    expect(res.status).toBe(200)
+
+    const { headers } = res
+    const csp = headers.get('content-security-policy')
+    const cspReportOnly = headers.get('content-security-policy-report-only')
+
+    expect(csp).toBeNull()
+    expect(cspReportOnly).toBeDefined()
+    expect(cspReportOnly).toContain("script-src 'self' 'strict-dynamic' example.com;")
+  })
+
+  it('disables report-only when explicitly set to false on deep route', async () => {
+    const res = await fetch('/csp-report-only/deep/disabled')
+    expect(res.status).toBe(200)
+
+    const { headers } = res
+    const csp = headers.get('content-security-policy')
+    const cspReportOnly = headers.get('content-security-policy-report-only')
+
+    expect(csp).toBeDefined()
+    expect(csp).toContain("script-src 'self' 'strict-dynamic' example.com;")
+    expect(cspReportOnly).toBeNull()
+  })
 })

--- a/test/perRoute.test.ts
+++ b/test/perRoute.test.ts
@@ -977,7 +977,7 @@ describe('[nuxt-security] Per-route Configuration', async () => {
     expect(rp).toBeNull()
   })
 
-  it('sets Content-Security-Policy-Report-Only header when report-only is true', async () => {
+  it('sets Content-Security-Policy-Report-Only header when contentSecurityPolicyReportOnly is true', async () => {
     const res = await fetch('/csp-report-only')
     expect(res.status).toBe(200)
 
@@ -988,10 +988,9 @@ describe('[nuxt-security] Per-route Configuration', async () => {
     expect(csp).toBeNull()
     expect(cspReportOnly).toBeDefined()
     expect(cspReportOnly).toContain("script-src 'self' 'strict-dynamic' example.com;")
-    expect(cspReportOnly).not.toContain('report-only')
   })
 
-  it('inherits report-only on deep routes', async () => {
+  it('inherits contentSecurityPolicyReportOnly on deep routes', async () => {
     const res = await fetch('/csp-report-only/deep/page')
     expect(res.status).toBe(200)
 
@@ -1004,7 +1003,7 @@ describe('[nuxt-security] Per-route Configuration', async () => {
     expect(cspReportOnly).toContain("script-src 'self' 'strict-dynamic' example.com;")
   })
 
-  it('disables report-only when explicitly set to false on deep route', async () => {
+  it('disables contentSecurityPolicyReportOnly when explicitly set to false on deep route', async () => {
     const res = await fetch('/csp-report-only/deep/disabled')
     expect(res.status).toBe(200)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

Support for Content-Security-Policy-Report-Only header, either globally or per route.

Resolves #605 


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)
