### PR TITLE
Fix/xss rich text and statusmessage bypass

### DIFF
--- a/src/runtime/server/middleware/xssValidator.ts
+++ b/src/runtime/server/middleware/xssValidator.ts
@@ -1,7 +1,7 @@
 import { defineEventHandler, createError, getQuery, readBody, readMultipartFormData } from 'h3'
-import { FilterXSS, type IFilterXSSOptions } from 'xss'
+import { type IFilterXSSOptions } from 'xss'
 import { resolveSecurityRules } from '../../nitro/context'
-import type { HTTPMethod } from '../../../types/middlewares'
+import { hasMaliciousPayload } from '../utils/xssPayload'
 
 export default defineEventHandler(async(event) => {
   const rules = resolveSecurityRules(event)
@@ -11,38 +11,19 @@ export default defineEventHandler(async(event) => {
       ...rules.xssValidator,
       escapeHtml: undefined
     }
-    if (rules.xssValidator.escapeHtml === false) {
-      // No html escaping (by default "<" is replaced by "&lt;" and ">" by "&gt;")
-      filterOpt.escapeHtml = (value: string) => value
-    }
-    const xssValidator = new FilterXSS(filterOpt)
-
     if (event.node.req.socket.readyState !== 'readOnly') {
-      if (
-        rules.xssValidator.methods &&
-        rules.xssValidator.methods.includes(
-          event.node.req.method! as HTTPMethod
-        )
-      ) {
+      const method = event.node.req.method
+      if (method && (rules.xssValidator.methods as readonly string[]).includes(method)) {
         const valueToFilter =
-          event.node.req.method === 'GET'
+            method === 'GET'
             ? getQuery(event)
             : event.node.req.headers['content-type']?.includes(
                 'multipart/form-data'
               )
             ? await readMultipartFormData(event)
             : await readBody(event)
-        // Fix for problems when one middleware is returning an error and it is catched in the next
         if (valueToFilter && Object.keys(valueToFilter).length) {
-          // Only skip XSS filtering if statusMessage === 'Bad Request' (for error propagation)
-          if (valueToFilter.statusMessage === 'Bad Request') {
-            return
-          }
-          const stringifiedValue = JSON.stringify(valueToFilter)
-          const processedValue = xssValidator.process(
-            JSON.stringify(valueToFilter)
-          )
-          if (processedValue !== stringifiedValue) {
+          if (hasMaliciousPayload(valueToFilter, filterOpt)) {
             const badRequestError = {
               statusCode: 400,
               statusMessage: 'Bad Request'

--- a/src/runtime/server/utils/xssPayload.ts
+++ b/src/runtime/server/utils/xssPayload.ts
@@ -1,0 +1,71 @@
+import { FilterXSS, type IFilterXSSOptions } from 'xss'
+
+const DANGEROUS_URL_ATTRS = new Set(['href', 'src', 'background', 'style'])
+const DANGEROUS_PROTOCOLS = /^\s*(?:javascript|vbscript|data\s*:\s*(?!image\/(?!svg)))/i
+const MAX_DEPTH = 20
+
+function createMaliciousHtmlDetector (baseOptions: IFilterXSSOptions) {
+  let isMalicious = false
+
+  const detector = new FilterXSS({
+    ...baseOptions,
+    onIgnoreTag (tag, html, options) {
+      if (!options.isClosing) {
+        isMalicious = true
+      }
+      return baseOptions.onIgnoreTag?.(tag, html, options)
+    },
+    onIgnoreTagAttr (tag, name, attrValue, isWhiteAttr) {
+      if (name.startsWith('on')) {
+        isMalicious = true
+      }
+      return baseOptions.onIgnoreTagAttr?.(tag, name, attrValue, isWhiteAttr)
+    },
+    safeAttrValue (tag, name, attrValue, cssFilter) {
+      if (DANGEROUS_URL_ATTRS.has(name) && DANGEROUS_PROTOCOLS.test(attrValue)) {
+        isMalicious = true
+      }
+      if (baseOptions.safeAttrValue) {
+        return baseOptions.safeAttrValue(tag, name, attrValue, cssFilter)
+      }
+      return attrValue
+    }
+  })
+
+  return (value: string): boolean => {
+    isMalicious = false
+    detector.process(value)
+    return isMalicious
+  }
+}
+
+function isRecord (value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function hasMaliciousPayload (value: unknown, options: IFilterXSSOptions): boolean {
+  const isMaliciousHtml = createMaliciousHtmlDetector(options)
+
+  const inspect = (current: unknown, depth = 0): boolean => {
+    if (depth > MAX_DEPTH) {
+      return true
+    }
+
+    if (typeof current === 'string') {
+      return isMaliciousHtml(current)
+    }
+
+    if (Array.isArray(current)) {
+      return current.some(item => inspect(item, depth + 1))
+    }
+
+    if (isRecord(current)) {
+      return Object.values(current)
+        .some(item => inspect(item, depth + 1))
+    }
+
+    return false
+  }
+
+  return inspect(value)
+}

--- a/test/fixtures/xssRichTextFalsePositive/app.vue
+++ b/test/fixtures/xssRichTextFalsePositive/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/test/fixtures/xssRichTextFalsePositive/nuxt.config.ts
+++ b/test/fixtures/xssRichTextFalsePositive/nuxt.config.ts
@@ -1,0 +1,8 @@
+export default defineNuxtConfig({
+  modules: ['../../../src/module'],
+  security: {
+    xssValidator: {
+      methods: ['POST'],
+    },
+  },
+})

--- a/test/fixtures/xssRichTextFalsePositive/server/api/rich-text.post.ts
+++ b/test/fixtures/xssRichTextFalsePositive/server/api/rich-text.post.ts
@@ -1,0 +1,10 @@
+import { defineEventHandler, readRawBody } from 'h3'
+
+export default defineEventHandler(async (event) => {
+  const body = await readRawBody(event, 'utf8')
+
+  return {
+    ok: true,
+    body,
+  }
+})

--- a/test/xssPayload.test.ts
+++ b/test/xssPayload.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest'
+import { hasMaliciousPayload } from '../src/runtime/server/utils/xssPayload'
+import type { IFilterXSSOptions } from 'xss'
+
+const defaultOptions: IFilterXSSOptions = {}
+
+describe('hasMaliciousPayload', () => {
+  describe('safe inputs', () => {
+    it('returns false for plain text', () => {
+      expect(hasMaliciousPayload('hello world', defaultOptions)).toBe(false)
+    })
+
+    it('returns false for allowed HTML tags', () => {
+      expect(hasMaliciousPayload('<p>paragraph</p>', defaultOptions)).toBe(false)
+    })
+
+    it('returns false for allowed attributes', () => {
+      expect(hasMaliciousPayload('<a href="https://example.com">link</a>', defaultOptions)).toBe(false)
+    })
+
+    it('returns false for rich text with inline styles', () => {
+      expect(hasMaliciousPayload('<p style="text-align:center">hello</p>', defaultOptions)).toBe(false)
+    })
+
+    it('returns false for numbers and booleans', () => {
+      expect(hasMaliciousPayload(42, defaultOptions)).toBe(false)
+      expect(hasMaliciousPayload(true, defaultOptions)).toBe(false)
+      expect(hasMaliciousPayload(null, defaultOptions)).toBe(false)
+    })
+
+    it('returns false for objects with safe string values', () => {
+      expect(hasMaliciousPayload({ name: 'John', bio: '<p>Hello</p>' }, defaultOptions)).toBe(false)
+    })
+
+    it('returns false for arrays with safe values', () => {
+      expect(hasMaliciousPayload(['hello', '<b>bold</b>'], defaultOptions)).toBe(false)
+    })
+  })
+
+  describe('malicious tags', () => {
+    it('detects <script> tags', () => {
+      expect(hasMaliciousPayload('<script>alert(1)</script>', defaultOptions)).toBe(true)
+    })
+
+    it('detects <iframe> tags', () => {
+      expect(hasMaliciousPayload('<iframe src="http://evil.com"></iframe>', defaultOptions)).toBe(true)
+    })
+
+    it('detects <object> tags', () => {
+      expect(hasMaliciousPayload('<object data="evil.swf"></object>', defaultOptions)).toBe(true)
+    })
+
+    it('detects <embed> tags', () => {
+      expect(hasMaliciousPayload('<embed src="evil.swf">', defaultOptions)).toBe(true)
+    })
+
+    it('detects <svg> with nested payload', () => {
+      expect(hasMaliciousPayload('<svg onload="alert(1)">', defaultOptions)).toBe(true)
+    })
+  })
+
+  describe('malicious attributes', () => {
+    it('detects onclick handlers', () => {
+      expect(hasMaliciousPayload('<div onclick="alert(1)">click</div>', defaultOptions)).toBe(true)
+    })
+
+    it('detects onerror handlers', () => {
+      expect(hasMaliciousPayload('<img onerror="alert(1)" src="x">', defaultOptions)).toBe(true)
+    })
+
+    it('detects onload handlers', () => {
+      expect(hasMaliciousPayload('<body onload="alert(1)">', defaultOptions)).toBe(true)
+    })
+
+    it('detects onmouseover handlers', () => {
+      expect(hasMaliciousPayload('<a onmouseover="alert(1)">hover</a>', defaultOptions)).toBe(true)
+    })
+  })
+
+  describe('dangerous URL attributes', () => {
+    it('detects javascript: in href', () => {
+      expect(hasMaliciousPayload('<a href="javascript:alert(1)">click</a>', defaultOptions)).toBe(true)
+    })
+
+    it('detects javascript: in src', () => {
+      expect(hasMaliciousPayload('<img src="javascript:alert(1)">', defaultOptions)).toBe(true)
+    })
+
+    it('detects data: URI in src', () => {
+      expect(hasMaliciousPayload('<img src="data:text/html,<script>alert(1)</script>">', defaultOptions)).toBe(true)
+    })
+  })
+
+  describe('nested payloads', () => {
+    it('detects malicious value in nested object', () => {
+      const payload = {
+        user: {
+          profile: {
+            bio: '<script>alert(1)</script>'
+          }
+        }
+      }
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(true)
+    })
+
+    it('detects malicious value in array', () => {
+      const payload = ['safe text', '<img onerror="alert(1)" src="x">']
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(true)
+    })
+
+    it('detects malicious value in array within object', () => {
+      const payload = {
+        tags: ['<b>bold</b>', '<script>alert(1)</script>']
+      }
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(true)
+    })
+
+    it('returns false when all nested values are safe', () => {
+      const payload = {
+        items: [
+          { title: 'Hello', content: '<p>World</p>' },
+          { title: 'Foo', content: '<strong>Bar</strong>' }
+        ]
+      }
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('returns false for empty string', () => {
+      expect(hasMaliciousPayload('', defaultOptions)).toBe(false)
+    })
+
+    it('returns false for empty object', () => {
+      expect(hasMaliciousPayload({}, defaultOptions)).toBe(false)
+    })
+
+    it('returns false for empty array', () => {
+      expect(hasMaliciousPayload([], defaultOptions)).toBe(false)
+    })
+
+    it('handles closing tag without opening (not malicious)', () => {
+      expect(hasMaliciousPayload('</script>', defaultOptions)).toBe(false)
+    })
+
+    it('detects uppercase event handlers', () => {
+      expect(hasMaliciousPayload('<div ONCLICK="alert(1)">x</div>', defaultOptions)).toBe(true)
+    })
+
+    it('detects mixed-case event handlers', () => {
+      expect(hasMaliciousPayload('<div OnError="alert(1)">x</div>', defaultOptions)).toBe(true)
+    })
+
+    it('handles strings that look like HTML but use unknown tags', () => {
+      // Non-whitelisted tags trigger detection even if harmless-looking
+      expect(hasMaliciousPayload('<custom-element>hello</custom-element>', defaultOptions)).toBe(true)
+    })
+
+    it('flags angle brackets that parse as tags (expected false positive)', () => {
+      // The xss parser sees `< 2 and 3 >` as a non-whitelisted tag — this is an acceptable
+      // trade-off for a security validator (overly cautious with angle brackets)
+      expect(hasMaliciousPayload('1 < 2 and 3 > 1', defaultOptions)).toBe(true)
+    })
+
+    it('flags any less-than that the parser sees as a tag opener (expected false positive)', () => {
+      // Even `a < b` is parsed as containing a tag — this is inherent to the xss library's parser
+      expect(hasMaliciousPayload('a < b', defaultOptions)).toBe(true)
+    })
+
+    it('allows greater-than signs (not tag openers)', () => {
+      expect(hasMaliciousPayload('a > b', defaultOptions)).toBe(false)
+    })
+
+    it('detects javascript: with leading whitespace in href', () => {
+      expect(hasMaliciousPayload('<a href="  javascript:alert(1)">x</a>', defaultOptions)).toBe(true)
+    })
+
+    it('detects vbscript: protocol in href', () => {
+      expect(hasMaliciousPayload('<a href="vbscript:alert(1)">x</a>', defaultOptions)).toBe(true)
+    })
+
+    it('allows legitimate data: image URIs in src', () => {
+      // data:image/png is considered safe by the xss library's default safeAttrValue
+      expect(hasMaliciousPayload('<img src="data:image/png;base64,iVBOR">', defaultOptions)).toBe(false)
+    })
+
+    it('detects data:image/svg+xml with embedded payload', () => {
+      // SVG can contain scripts and event handlers
+      expect(hasMaliciousPayload('<img src="data:image/svg+xml,<svg onload=alert(1)>">', defaultOptions)).toBe(true)
+    })
+
+    it('allows legitimate raster data URIs (png, jpg, etc.)', () => {
+      expect(hasMaliciousPayload('<img src="data:image/png;base64,iVBOR">', defaultOptions)).toBe(false)
+      expect(hasMaliciousPayload('<img src="data:image/jpeg;base64,/9j/4AAQ">', defaultOptions)).toBe(false)
+      expect(hasMaliciousPayload('<img src="data:image/gif;base64,R0lGODlh">', defaultOptions)).toBe(false)
+      expect(hasMaliciousPayload('<img src="data:image/webp;base64,UklGRiIAAABX">', defaultOptions)).toBe(false)
+    })
+
+    it('detects data: image/ protocol with leading whitespace', () => {
+      expect(hasMaliciousPayload('<img src="  data:image/svg+xml,<svg>">', defaultOptions)).toBe(true)
+      expect(hasMaliciousPayload('<a href=" data: text/html , <script>">x</a>', defaultOptions)).toBe(true)
+    })
+
+    it('detects SVG with event handler', () => {
+      expect(hasMaliciousPayload('<svg><animate onbegin="alert(1)"></animate></svg>', defaultOptions)).toBe(true)
+    })
+
+    it('detects payload hidden in deeply nested structure', () => {
+      const payload = { a: { b: { c: { d: { e: '<script>x</script>' } } } } }
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(true)
+    })
+
+    it('handles object with prototype pollution keys safely', () => {
+      const payload = { __proto__: '<script>x</script>', constructor: '<img onerror="x" src="y">' }
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(true)
+    })
+
+    it('handles multipart-like array of objects (as returned by readMultipartFormData)', () => {
+      const payload = [
+        { name: 'file', filename: 'safe.txt', data: Buffer.from('hello') },
+        { name: 'field', data: '<script>alert(1)</script>' }
+      ]
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(true)
+    })
+
+    it('returns false for multipart-like array with safe values', () => {
+      const payload = [
+        { name: 'title', data: 'My Document' },
+        { name: 'body', data: '<p>Safe content</p>' }
+      ]
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(false)
+    })
+
+    it('returns true when nesting exceeds depth limit (safety cutoff)', () => {
+      // Build a payload nested beyond MAX_DEPTH (20)
+      let payload: any = { value: '<script>x</script>' }
+      for (let i = 0; i < 25; i++) {
+        payload = { safe: payload }
+      }
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(true)
+    })
+
+    it('still detects malicious content at edge of depth limit', () => {
+      // Exactly at MAX_DEPTH, detection should still work
+      let payload: any = { value: '<script>x</script>' }
+      for (let i = 0; i < 19; i++) {
+        payload = { safe: payload }
+      }
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(true)
+    })
+
+    it('returns false for safe content deep but within depth limit', () => {
+      let payload: any = { value: '<p>safe</p>' }
+      for (let i = 0; i < 15; i++) {
+        payload = { safe: payload }
+      }
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(false)
+    })
+
+    it('does not skip detection when payload contains statusMessage', () => {
+      // statusMessage is user-controlled request data — must not affect detection
+      const payload = { statusMessage: 'Bad Request', description: '<script>alert(1)</script>' }
+      expect(hasMaliciousPayload(payload, defaultOptions)).toBe(true)
+    })
+  })
+
+  describe('custom options', () => {
+    it('respects custom whiteList allowing script tags', () => {
+      const options: IFilterXSSOptions = {
+        whiteList: { script: [], p: [], a: ['href'] }
+      }
+      expect(hasMaliciousPayload('<script>alert(1)</script>', options)).toBe(false)
+    })
+
+    it('detects non-whitelisted tags with custom whiteList', () => {
+      const options: IFilterXSSOptions = {
+        whiteList: { p: [], a: ['href'] }
+      }
+      expect(hasMaliciousPayload('<div>hello</div>', options)).toBe(true)
+    })
+  })
+})

--- a/test/xssValidator.richTextFalsePositive.test.ts
+++ b/test/xssValidator.richTextFalsePositive.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { fetch, setup } from '@nuxt/test-utils'
+
+describe('[nuxt-security] XSS validator rich-text false positive', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('./fixtures/xssRichTextFalsePositive', import.meta.url)),
+  })
+
+  it('allows a rich-text-like JSON payload sent to POST endpoints', async () => {
+    const res = await fetch('/api/rich-text', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        description: '<p style="text-align:center">hello</p>',
+      }),
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.statusText).toBe('OK')
+  })
+})


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Resolves: #720

Replaces the XSS validator's stringify-and-compare detection with hook-based malicious payload detection. The old approach compared `xss.process(JSON.stringify(body))` to the input and rejected on *any* difference, which caused false positives for legitimate rich-text HTML like e.g. `<p style="text-align:center">hello</p>`.

The new approach uses the `xss` library's hooks to detect specific malicious patterns:
- Non-whitelisted tags (`<script>`, `<iframe>`, `<svg>`, etc.) via `onIgnoreTag`
- Event handler attributes (`on*`) via `onIgnoreTagAttr`
- Dangerous URL protocols (`javascript:`, `vbscript:`, non-image `data:`) via `safeAttrValue` with an inline regex

Also fixes a security bypass where user-controlled `statusMessage: "Bad Request"` in the request body would skip XSS validation entirely.

Defense-in-depth:
- Recursive payload traversal with depth limit (20) to prevent stack overflow on maliciously nested payloads
- `FilterXSS` instance reused per request instead of per-string
- Regex blocks `data:image/svg+xml` (which can embed scripts) while allowing raster image formats (png, jpeg, gif, webp)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes (if not applicable, please state why)